### PR TITLE
Fix typo in function name (regression for Windows builds)

### DIFF
--- a/src/allheaders.h
+++ b/src/allheaders.h
@@ -2537,7 +2537,7 @@ LEPT_DLL extern l_uint32 convertOnBigEnd32 ( l_uint32 wordin );
 LEPT_DLL extern FILE * fopenReadStream ( const char *filename );
 LEPT_DLL extern FILE * fopenWriteStream ( const char *filename, const char *modestring );
 LEPT_DLL extern FILE * fopenReadFromMemory ( const l_uint8 *data, size_t size );
-LEPT_DLL extern FILE * fopenWriteWinTmpfile (  );
+LEPT_DLL extern FILE * fopenWriteWinTempfile (  );
 LEPT_DLL extern FILE * lept_fopen ( const char *filename, const char *mode );
 LEPT_DLL extern l_int32 lept_fclose ( FILE *fp );
 LEPT_DLL extern void * lept_calloc ( size_t nmemb, size_t size );

--- a/src/utils.c
+++ b/src/utils.c
@@ -91,7 +91,7 @@
  *           FILE      *fopenReadFromMemory()
  *
  *       Opening a windows tmpfile for writing
- *           FILE      *fopenWriteWinTmpfile()
+ *           FILE      *fopenWriteWinTempfile()
  *
  *       Cross-platform functions that avoid C-runtime boundary crossing
  *       with Windows DLLs
@@ -1894,7 +1894,7 @@ FILE       *fp;
  *                Opening a windows tmpfile for writing               *
  *--------------------------------------------------------------------*/
 /*!
- *  fopenWriteWinTmpfile()
+ *  fopenWriteWinTempfile()
  *
  *      Return: file stream, or null on error
  *
@@ -1904,7 +1904,7 @@ FILE       *fp;
  *          implementation.
  */
 FILE *
-fopenWriteWinTmpfile()
+fopenWriteWinTempfile()
 {
 #ifdef _WIN32
 l_int32     handle;
@@ -1913,7 +1913,7 @@ char        filename[64];
 const char  fn_template[] = "mkstemp.XXXXXX";
 FILE       *fp;
 
-    PROCNAME("fopenWriteWinTmpfile");
+    PROCNAME("fopenWriteWinTempfile");
 
     tmpdir = getenv("TMP");
     snprintf(filename, sizeof(filename), "%s/%s", tmpdir ? tmpdir : ".",


### PR DESCRIPTION
Commit ca9d16af54074812331fbc08a76a0410f6955796 introduced
a new function fopenWriteWinTempfile, but used
fopenWriteWinTmpfile for the implementation.

This caused builds for Windows to fail.

Signed-off-by: Stefan Weil <sw@weilnetz.de>