### PR TITLE
Fix use of fmemopen in src/utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -182,6 +182,10 @@
  *         lept_fopen(), lept_fclose(), lept_calloc() and lept_free().
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif  /* HAVE_CONFIG_H */
+
 #include <string.h>
 #include <time.h>
 #ifdef _MSC_VER


### PR DESCRIPTION
src/utils.c uses the macro HAVE_FMEMOPEN which comes from config_auto.h,
so it must include that file.

Signed-off-by: Stefan Weil <sw@weilnetz.de>