### PR TITLE
pageseg.c: csize almost always 0

### DIFF
--- a/src/pageseg.c
+++ b/src/pageseg.c
@@ -943,7 +943,7 @@ PIXA    *pixa1, *pixa2, *pixa3, *pixad;
         L_INFO("Resolution is not set: setting to 300 ppi\n", procName);
         res = 300;
     }
-    csize = L_MIN(120., 60.0 * (res / 300));
+    csize = L_MIN(120., 60.0 * res / 300);
     snprintf(buf, sizeof(buf), "c%d.1 + o20.1", csize);
     pix3 = pixMorphCompSequence(pix2, buf, 0);
 


### PR DESCRIPTION
If (res / 300) is evaluated before multiplying with 60.0,
then every resolution below 300 dpi results in csize being 0.
I believe the intention here was to linearily scale 60.0 with
the resolution, i.e. 30.0 for 150 dpi, 120.0 for 600 dpi.

Note: pixExtractTextLines() fails with the following sequence of errors without this patch:
```
*** op: c0.1; w = 0, h = 1; must both be > 0
Error in pixMorphCompSequence: sequence not valid
Error in pixConnComp: pixs not defined
Error in pixaSelectBySize: pixas not defined
Error in pixaGetBoxa: pixa not defined
Error in boxaGetCount: boxa not defined
Error in pixClipRectangles: boxa not defined
```