### PR TITLE
Deduplicate endianness test in CMake

### DIFF
--- a/cmake/Configure.cmake
+++ b/cmake/Configure.cmake
@@ -75,7 +75,7 @@ set(functions_list
 )
 check_functions(functions_list)
 
-test_big_endian(WORDS_BIGENDIAN)
+test_big_endian(BIG_ENDIAN)
 
 set(STDC_HEADERS 1)
 
@@ -131,10 +131,6 @@ file(APPEND ${AUTOCONFIG_SRC} "
 
 /* Define to 1 if you have zlib. */
 #cmakedefine HAVE_LIBZ 1
-
-/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
-   significant byte first (like Motorola and SPARC, unlike Intel). */
-#cmakedefine WORDS_BIGENDIAN 1
 
 
 #ifdef HAVE_OPENJPEG_2_0_OPENJPEG_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,8 +14,6 @@ if (MSVC)
     set_source_files_properties(${src} PROPERTIES LANGUAGE CXX)
 endif()
 
-test_big_endian(BIG_ENDIAN)
-
 if(BIG_ENDIAN)
   set(ENDIANNESS L_BIG_ENDIAN)
 else()


### PR DESCRIPTION
The `WORDS_BIGENDIAN` macro is set by Autotools but we don't use it.

Please let @egorpugin confirm before merging this. I didn't move the other lines above `configure_file` because the `ENDIANNESS` and `APPLE_UNIVERSAL_BUILD` variables are used directly by that and nowhere else so separating them would be confusing.