### PR TITLE
doxygen: fix remaining doxygen warnings

### DIFF
--- a/src/bmf.c
+++ b/src/bmf.c
@@ -467,9 +467,9 @@ PIXA    *pixa;
  * \brief   pixaGenerateFontFromString()
  *
  * \param[in]    fontsize 4, 6, 8, ... , 20, in pts at 300 ppi
- * \param[out]   pbl1 baseline of row 1
- * \param[out]   pbl2 baseline of row 2
- * \param[out]   pbl3 baseline of row 3
+ * \param[out]   pbl0 baseline of row 1
+ * \param[out]   pbl1 baseline of row 2
+ * \param[out]   pbl2 baseline of row 3
  * \return  pixa of font bitmaps for 95 characters, or NULL on error
  *
  * <pre>

--- a/src/morphapp.c
+++ b/src/morphapp.c
@@ -320,7 +320,7 @@ PIXA    *pixad;
  * \param[in]    connectivity 4 or 8, used on mask
  * \param[in]    minw  minimum width to consider; use 0 or 1 for any width
  * \param[in]    minh  minimum height to consider; use 0 or 1 for any height
- * \param[in]    &boxa [optional] return boxa of c.c. in pixm
+ * \param[out]   pboxa [optional] return boxa of c.c. in pixm
  * \return  pixd, or NULL on error
  *
  * <pre>

--- a/src/numafunc1.c
+++ b/src/numafunc1.c
@@ -2266,14 +2266,14 @@ NUMA       *naiy;
 /*!
  * \brief   numaSortGeneral()
  *
- * \param[in]    na source numa
- * \param[out]   pnasort [optional] sorted numa
- * \param[out]   pnaindex [optional] index of elements in na associated
- *                       with each element of nasort
- * \param[out]   ninainvert [optional] index of elements in nasort associated
- *                        with each element of na
+ * \param[in]    na        source numa
+ * \param[out]   pnasort   [optional] sorted numa
+ * \param[out]   pnaindex  [optional] index of elements in na associated
+ *                         with each element of nasort
+ * \param[out]   pnainvert [optional] index of elements in nasort associated
+ *                         with each element of na
  * \param[in]    sortorder L_SORT_INCREASING or L_SORT_DECREASING
- * \param[in]    sorttype L_SHELL_SORT or L_BIN_SORT
+ * \param[in]    sorttype  L_SHELL_SORT or L_BIN_SORT
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/numafunc2.c
+++ b/src/numafunc2.c
@@ -1349,8 +1349,8 @@ numaGetHistogramStats(NUMA       *nahisto,
  * \param[out]   pxmean [optional] mean value of histogram
  * \param[out]   pxmedian [optional] median value of histogram
  * \param[out]   pxmode [optional] mode value of histogram:
- *                     xmode = x(imode), where y(xmode) >= y(x(i) for
- * \param[in]           all i != imode)
+ *                      xmode = x(imode), where y(xmode) >= y(x(i)) for
+ *                      all i != imode
  * \param[out]   pxvariance [optional] variance of x
  * \return  0 if OK, 1 on error
  *

--- a/src/pdfio1.c
+++ b/src/pdfio1.c
@@ -317,7 +317,7 @@ size_t    nbytes;
 /*!
  * \brief   saConvertFilesToPdfData()
  *
- * \param[in]    sarray of pathnames for images
+ * \param[in]    sa string array of pathnames for images
  * \param[in]    res input resolution of all images
  * \param[in]    scalefactor scaling factor applied to each image; > 0.0
  * \param[in]    type encoding type (L_JPEG_ENCODE, L_G4_ENCODE,

--- a/src/pix1.c
+++ b/src/pix1.c
@@ -207,11 +207,17 @@ static void pixFree(PIX *pix);
  *  to specify other functions to use.                                     *
  *-------------------------------------------------------------------------*/
 
+/*! Allocator function type */
+typedef void *(*alloc_fn)(size_t);
+
+/*! Deallocator function type */
+typedef void (*dealloc_fn)(void *);
+
 /*! Pix memory manager function ptrs */
 struct PixMemoryManager
 {
-    void     *(*allocator)(size_t);
-    void      (*deallocator)(void *);
+    alloc_fn   allocator;
+    dealloc_fn deallocator;
 };
 
 /*! Default Pix memory manager */
@@ -272,8 +278,8 @@ pix_free(void  *ptr)
  * </pre>
  */
 void
-setPixMemoryManager(void  *((*allocator)(size_t)),
-                    void   ((*deallocator)(void *)))
+setPixMemoryManager(alloc_fn   allocator,
+                    dealloc_fn deallocator)
 {
     if (allocator) pix_mem_manager.allocator = allocator;
     if (deallocator) pix_mem_manager.deallocator = deallocator;

--- a/src/pixabasic.c
+++ b/src/pixabasic.c
@@ -374,8 +374,7 @@ PIXA    *pixa;
 /*!
  * \brief   pixaDestroy()
  *
- * \param[in]    &pixa <can be nulled>
- * \return  void
+ * \param[in,out]  ppixa can be nulled
  *
  * <pre>
  * Notes:
@@ -417,12 +416,12 @@ PIXA    *pixa;
 /*!
  * \brief   pixaCopy()
  *
- * \param[in]    pixas
+ * \param[in]    pixa
  * \param[in]    copyflag see pix.h for details:
- * \param[in]      L_COPY makes a new pixa and copies each pix and each box
- * \param[in]      L_CLONE gives a new ref-counted handle to the input pixa
- * \param[in]      L_COPY_CLONE makes a new pixa and inserts clones of
- * \param[in]          all pix and boxes
+ *                 L_COPY makes a new pixa and copies each pix and each box;
+ *                 L_CLONE gives a new ref-counted handle to the input pixa;
+ *                 L_COPY_CLONE makes a new pixa and inserts clones of
+ *                     all pix and boxes
  * \return  new pixa, or NULL on error
  */
 PIXA *
@@ -1725,11 +1724,11 @@ PIXAA   *paa;
  * \param[in]    paa
  * \param[in]    pixa  to be added
  * \param[in]    copyflag:
- * \param[in]      L_INSERT inserts the pixa directly
- * \param[in]      L_COPY makes a new pixa and copies each pix and each box
- * \param[in]      L_CLONE gives a new handle to the input pixa
- * \param[in]      L_COPY_CLONE makes a new pixa and inserts clones of
- * \param[in]          all pix and boxes
+ *                 L_INSERT inserts the pixa directly;
+ *                 L_COPY makes a new pixa and copies each pix and each box;
+ *                 L_CLONE gives a new handle to the input pixa;
+ *                 L_COPY_CLONE makes a new pixa and inserts clones of
+ *                     all pix and boxes
  * \return  0 if OK; 1 on error
  */
 l_int32

--- a/src/pixacc.c
+++ b/src/pixacc.c
@@ -147,8 +147,7 @@ PIXACC  *pixacc;
 /*!
  * \brief   pixaccDestroy()
  *
- * \param[in]    &pixacc <can be null>
- * \return  void
+ * \param[in,out] ppixacc to be nulled
  *
  * <pre>
  * Notes:

--- a/src/pixafunc2.c
+++ b/src/pixafunc2.c
@@ -236,7 +236,7 @@ PIX     *pixt, *pixd;
  * \param[in]    pixa
  * \param[in]    w, h if set to 0, determines the size from the
  *                    b.b. of the components in pixa
- * \param[in]    color background color to use
+ * \param[in]    bgcolor background color to use
  * \return  pix, or NULL on error
  *
  * <pre>
@@ -396,7 +396,7 @@ PIXCMAP  *cmap;
 /*!
  * \brief   pixaDisplayLinearly()
  *
- * \param[in]    pixa
+ * \param[in]    pixas
  * \param[in]    direction L_HORIZ or L_VERT
  * \param[in]    scalefactor applied to every pix; use 1.0 for no scaling
  * \param[in]    background 0 for white, 1 for black; this is the color
@@ -1333,7 +1333,7 @@ PIXA     *pixad;
  * \brief   pixaDisplayTiledByIndex()
  *
  * \param[in]    pixa
- * \param[in]    numa with indices corresponding to the pix in pixa
+ * \param[in]    na numa with indices corresponding to the pix in pixa
  * \param[in]    width each pix is scaled to this width
  * \param[in]    spacing  between images, and on outside
  * \param[in]    border width of black border added to each image;
@@ -1539,7 +1539,7 @@ PIXA    *pixa;
  * \param[in]    paa with pix that may have different depths
  * \param[in]    xspace between pix in pixa
  * \param[in]    yspace between pixa
- * \param[in]    max width of output pix
+ * \param[in]    maxw max width of output pix
  * \return  pixd, or NULL on error
  *
  * <pre>
@@ -1810,7 +1810,7 @@ PIXA    *pixad;
  * \brief   pixaConvertTo8Color()
  *
  * \param[in]    pixas
- * \param[in]    ditherflag 1 to dither if necessary; 0 otherwise
+ * \param[in]    dither 1 to dither if necessary; 0 otherwise
  * \return  pixad each pix is 8 bpp, or NULL on error
  *
  * <pre>
@@ -2115,7 +2115,7 @@ PIXA    *pixa1;
 /*!
  * \brief   convertToNUpFiles()
  *
- * \param[in]    indir full path to directory of images
+ * \param[in]    dir full path to directory of images
  * \param[in]    substr [optional] can be null
  * \param[in]    nx, ny in [1, ... 50], tiling factors in each direction
  * \param[in]    tw target width, in pixels; must be >= 20

--- a/src/pixalloc.c
+++ b/src/pixalloc.c
@@ -257,9 +257,6 @@ L_PTRAA          *paa;
 /*!
  * \brief   pmsDestroy()
  *
- * \param[in]    none
- * \return  void
- *
  * <pre>
  * Notes:
  *      (1) Important: call this function at the end of the program, after
@@ -509,9 +506,6 @@ L_PIX_MEM_STORE  *pms;
 
 /*!
  * \brief   pmsLogInfo()
- *
- * \param[in]    none
- * \return  void
  */
 void
 pmsLogInfo()

--- a/src/pixcomp.c
+++ b/src/pixcomp.c
@@ -434,7 +434,7 @@ pixcompGetDimensions(PIXC     *pixc,
  * \param[in]    comptype IFF_DEFAULT, IFF_TIFF_G4, IFF_PNG, IFF_JFIF_JPEG
  * \param[in]    d pix depth
  * \param[in]    cmapflag 1 if pix to be compressed as a colormap; 0 otherwise
- * \param[in]    &format return IFF_TIFF, IFF_PNG or IFF_JFIF_JPEG
+ * \param[out]   pformat return IFF_TIFF, IFF_PNG or IFF_JFIF_JPEG
  * \return  0 if OK; 1 on error
  *
  * <pre>
@@ -756,7 +756,7 @@ SARRAY   *sa;
 /*!
  * \brief   pixacompCreateFromSA()
  *
- * \param[in]    sarray full pathnames for all files
+ * \param[in]    sa full pathnames for all files
  * \param[in]    comptype IFF_DEFAULT, IFF_TIFF_G4, IFF_PNG, IFF_JFIF_JPEG
  * \return  pixac, or NULL on error
  *
@@ -1173,7 +1173,7 @@ PIXC    *pixc;
 /*!
  * \brief   pixacompGetPixDimensions()
  *
- * \param[in]    pixa
+ * \param[in]    pixac
  * \param[in]    index caller's view of index within pixac; includes offset
  * \param[out]   pw, ph, pd [optional]  each can be null
  * \return  0 if OK, 1 on error

--- a/src/pixconv.c
+++ b/src/pixconv.c
@@ -165,7 +165,7 @@ static l_int32  var_NEUTRAL_BOOST_VAL = 180;
 /*!
  * \brief   pixThreshold8()
  *
- * \param[in]    pix 8 bpp grayscale
+ * \param[in]    pixs 8 bpp grayscale
  * \param[in]    d destination depth: 1, 2, 4 or 8
  * \param[in]    nlevels number of levels to be used for colormap
  * \param[in]    cmapflag 1 if makes colormap; 0 otherwise
@@ -711,7 +711,7 @@ PIXCMAP   *cmap;
 /*!
  * \brief   pixConvertRGBToLuminance()
  *
- * \param[in]    pix 32 bpp RGB
+ * \param[in]    pixs 32 bpp RGB
  * \return  8 bpp pix, or NULL on error
  *
  * <pre>
@@ -729,7 +729,7 @@ pixConvertRGBToLuminance(PIX *pixs)
 /*!
  * \brief   pixConvertRGBToGray()
  *
- * \param[in]    pix 32 bpp RGB
+ * \param[in]    pixs 32 bpp RGB
  * \param[in]    rwt, gwt, bwt  non-negative; these should add to 1.0,
  *                              or use 0.0 for default
  * \return  8 bpp pix, or NULL on error
@@ -804,7 +804,7 @@ PIX       *pixd;
 /*!
  * \brief   pixConvertRGBToGrayFast()
  *
- * \param[in]    pix 32 bpp RGB
+ * \param[in]    pixs 32 bpp RGB
  * \return  8 bpp pix, or NULL on error
  *
  * <pre>
@@ -857,7 +857,7 @@ PIX       *pixd;
 /*!
  * \brief   pixConvertRGBToGrayMinMax()
  *
- * \param[in]    pix 32 bpp RGB
+ * \param[in]    pixs 32 bpp RGB
  * \param[in]    type L_CHOOSE_MIN, L_CHOOSE_MAX, L_CHOOSE_MAXDIFF,
  *                    L_CHOOSE_MIN_BOOST, L_CHOOSE_MAX_BOOST
  * \return  8 bpp pix, or NULL on error
@@ -2975,7 +2975,7 @@ PIX       *pixt, *pixd;
 /*!
  * \brief   pixConvert8To32()
  *
- * \param[in]    pix 8 bpp
+ * \param[in]    pixs 8 bpp
  * \return  32 bpp rgb pix, or NULL on error
  *
  * <pre>

--- a/src/pixlabel.c
+++ b/src/pixlabel.c
@@ -317,7 +317,7 @@ PTAA    *ptaa;
  *
  * \param[in]     pixs 32 bpp, with pixels labelled by c.c.
  * \param[in]     ptaa with each pta of pixel locations indexed by c.c.
- * \param[in]     &ncc number of c.c
+ * \param[out]    pncc number of c.c
  * \param[in]     x,y location of added pixel
  * \param[in]     debug 0 for no output; otherwise output whenever
  *                      debug <= nvals, up to debug == 3

--- a/src/psio2.c
+++ b/src/psio2.c
@@ -233,31 +233,39 @@ PIX     *pixc;
 /*!
  * \brief   pixWriteStringPS()
  *
- * \param[in]    pixs:  all depths, colormap OK
- * \param[in]    box:  a If box == null, image is placed, optionally scaled,
- * \param[in]              in a standard b.b. at the center of the page.
- * \param[in]              This is to be used when another program like
- * \param[in]              TeX through epsf places the image.
- * \param[in]          b If box != null, image is placed without a
- * \param[in]              b.b. at the specified page location and with
- * \param[in]              optional scaling.  This is to be used when
- * \param[in]              you want to specify exactly where and optionally
- *                        how big you want the image to be.
- * \param[in]              Note that all coordinates are in PS convention,
- * \param[in]              with 0,0 at LL corner of the page:
- * \param[in]                  x,y    location of LL corner of image, in mils.
- * \param[in]                  w,h    scaled size, in mils.  Use 0 to
- * \param[in]                           scale with "scale" and "res" input.
- * \param[in]    res:  resolution, in printer ppi.  Use 0 for default 300 ppi.
- * \param[in]    scale: scale factor.  If no scaling is desired, use
- * \param[in]           either 1.0 or 0.0.   Scaling just resets the resolution
- * \param[in]           parameter; the actual scaling is done in the
- * \param[in]           interpreter at rendering time.  This is important:
- * \param[in]           it allows you to scale the image up without
- * \param[in]           increasing the file size.
+ * \param[in]    pixs   all depths, colormap OK
+ * \param[in]    box    bounding box; can be NULL
+ * \param[in]    res    resolution, in printer ppi.  Use 0 for default 300 ppi.
+ * \param[in]    scale  scale factor.  If no scaling is desired, use
+ *                      either 1.0 or 0.0.   Scaling just resets the resolution
+ *                      parameter; the actual scaling is done in the
+ *                      interpreter at rendering time.  This is important:
+ *                      it allows you to scale the image up without
+ *                      increasing the file size.
  * \return  ps string if OK, or NULL on error
  *
  * <pre>
+ * a) If %box == NULL, image is placed, optionally scaled,
+ *      in a standard b.b. at the center of the page.
+ *      This is to be used when another program like
+ *      TeX through epsf places the image.
+ * b) If %box != NULL, image is placed without a
+ *      b.b. at the specified page location and with
+ *      optional scaling.  This is to be used when
+ *      you want to specify exactly where and optionally
+ *      how big you want the image to be.
+ *      Note that all coordinates are in PS convention,
+ *      with 0,0 at LL corner of the page:
+ *          x,y    location of LL corner of image, in mils.
+ *          w,h    scaled size, in mils.  Use 0 to
+ *                 scale with "scale" and "res" input.
+ *
+ * %scale: If no scaling is desired, use either 1.0 or 0.0.
+ * Scaling just resets the resolution parameter; the actual
+ * scaling is done in the interpreter at rendering time.
+ * This is important: * it allows you to scale the image up
+ * without increasing the file size.
+ *
  * Notes:
  *      (1) OK, this seems a bit complicated, because there are various
  *          ways to scale and not to scale.  Here's a summary:
@@ -388,8 +396,8 @@ PIX       *pix;
  * \param[in]    psbpl raster bytes/line, when packed to the byte boundary
  * \param[in]    bps bits/sample: either 1 or 8
  * \param[in]    xpt, ypt location of LL corner of image, in pts, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                    of the page
  * \param[in]    wpt, hpt rendered image size in pts
  * \param[in]    boxflag 1 to print out bounding box hint; 0 to skip
  * \return  PS string, or NULL on error
@@ -495,10 +503,10 @@ SARRAY  *sa;
  * \param[in]    hpix pix height in pixels
  * \param[in]    res of printer; use 0 for default
  * \param[in]    scale use 1.0 or 0.0 for no scaling
- * \param[in]    &xpt location of llx in pts
- * \param[in]    &ypt location of lly in pts
- * \param[in]    &wpt image width in pts
- * \param[in]    &hpt image height in pts
+ * \param[out]   pxpt location of llx in pts
+ * \param[out]   pypt location of lly in pts
+ * \param[out]   pwpt image width in pts
+ * \param[out]   phpt image height in pts
  * \return  void no arg checking
  *
  * <pre>
@@ -685,8 +693,8 @@ L_COMP_DATA  *cid;
  * \param[in]    fileout output ps file
  * \param[in]    operation "w" for write; "a" for append
  * \param[in]    x, y location of LL corner of image, in pixels, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                    of the page
  * \param[in]    res resolution of the input image, in ppi; use 0 for default
  * \param[in]    scale scaling by printer; use 0.0 or 1.0 for no scaling
  * \param[in]    pageno page number; must start with 1; you can use 0
@@ -785,11 +793,11 @@ l_int32  nbytes;
  *      Generates PS string in jpeg format from jpeg file
  *
  * \param[in]    filein input jpeg file
- * \param[out]   ppoutstr PS string
+ * \param[out]   poutstr PS string
  * \param[out]   pnbytes number of bytes in PS string
  * \param[in]    x, y location of LL corner of image, in pixels, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                     of the page
  * \param[in]    res resolution of the input image, in ppi; use 0 for default
  * \param[in]    scale scaling by printer; use 0.0 or 1.0 for no scaling
  * \param[in]    pageno page number; must start with 1; you can use 0
@@ -885,8 +893,8 @@ L_COMP_DATA  *cid;
  * \param[in]    filein [optional] input jpeg filename; can be null
  * \param[in]    cid jpeg compressed image data
  * \param[in]    xpt, ypt location of LL corner of image, in pts, relative
- *                        to the PostScript origin (0,0 at the LL corner
- * \param[in]              of the page)
+ *                        to the PostScript origin (0,0) at the LL corner
+ *                        of the page
  * \param[in]    wpt, hpt rendered image size in pts
  * \param[in]    pageno page number; must start with 1; you can use 0
  *                      if there is only one page.
@@ -1081,8 +1089,8 @@ L_COMP_DATA  *cid;
  * \param[in]    fileout output ps file
  * \param[in]    operation "w" for write; "a" for append
  * \param[in]    x, y location of LL corner of image, in pixels, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                    of the page
  * \param[in]    res resolution of the input image, in ppi; typ. values
  *                   are 300 and 600; use 0 for automatic determination
  *                   based on image size
@@ -1091,7 +1099,7 @@ L_COMP_DATA  *cid;
  *                      if there is only one page.
  * \param[in]    maskflag boolean: use TRUE if just painting through fg;
  *                        FALSE if painting both fg and bg.
- *              endpage (boolean: use TRUE if this is the last image to be
+ * \param[in]    endpage boolean: use TRUE if this is the last image to be
  *                       added to the page; FALSE otherwise
  * \return  0 if OK, 1 on error
  *
@@ -1172,11 +1180,11 @@ l_int32  nbytes;
  * \brief   convertG4ToPSString()
  *
  * \param[in]    filein input tiff g4 file
- * \param[out]   ppoutstr PS string
+ * \param[out]   poutstr PS string
  * \param[out]   pnbytes number of bytes in PS string
  * \param[in]    x, y location of LL corner of image, in pixels, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                    of the page
  * \param[in]    res resolution of the input image, in ppi; typ. values
  *                   are 300 and 600; use 0 for automatic determination
  *                   based on image size
@@ -1185,7 +1193,7 @@ l_int32  nbytes;
  *                      if there is only one page.
  * \param[in]    maskflag boolean: use TRUE if just painting through fg;
  *                        FALSE if painting both fg and bg.
- *              endpage (boolean: use TRUE if this is the last image to be
+ * \param[in]    endpage boolean: use TRUE if this is the last image to be
  *                       added to the page; FALSE otherwise
  * \return  0 if OK, 1 on error
  *
@@ -1275,12 +1283,12 @@ L_COMP_DATA  *cid;
  * \param[in]    filein [optional] input tiff g4 file; can be null
  * \param[in]    cid g4 compressed image data
  * \param[in]    xpt, ypt location of LL corner of image, in pts, relative
- *                        to the PostScript origin (0,0 at the LL corner
- * \param[in]              of the page)
+ *                        to the PostScript origin (0,0) at the LL corner
+ *                        of the page
  * \param[in]    wpt, hpt rendered image size in pts
  * \param[in]    maskflag boolean: use TRUE if just painting through fg;
  *                        FALSE if painting both fg and bg.
- *              pageno (page number; must start with 1; you can use 0
+ * \param[in]    pageno page number; must start with 1; you can use 0
  *                      if there is only one page.
  * \param[in]    endpage boolean: use TRUE if this is the last image to be
  *                       added to the page; FALSE otherwise
@@ -1412,7 +1420,7 @@ SARRAY  *sa;
  * \param[in]    fileout output ps file
  * \param[in]    tempfile [optional] for temporary g4 tiffs;
  *                        use NULL for default
- * \param[in]    factor for filling 8.5 x 11 inch page;
+ * \param[in]    fillfract factor for filling 8.5 x 11 inch page;
  *                      use 0.0 for DEFAULT_FILL_FRACTION
  * \return  0 if OK, 1 on error
  *
@@ -1565,8 +1573,8 @@ L_COMP_DATA  *cid;
  * \param[in]    fileout output ps file
  * \param[in]    operation "w" for write; "a" for append
  * \param[in]    x, y location of LL corner of image, in pixels, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                    of the page
  * \param[in]    res resolution of the input image, in ppi; use 0 for default
  * \param[in]    scale scaling by printer; use 0.0 or 1.0 for no scaling
  * \param[in]    pageno page number; must start with 1; you can use 0
@@ -1664,11 +1672,11 @@ l_int32  nbytes;
  *      Generates level 3 PS string in flate compressed format.
  *
  * \param[in]    filein input image file
- * \param[out]   ppoutstr PS string
+ * \param[out]   poutstr PS string
  * \param[out]   pnbytes number of bytes in PS string
  * \param[in]    x, y location of LL corner of image, in pixels, relative
- *                    to the PostScript origin (0,0 at the LL corner
- * \param[in]          of the page)
+ *                    to the PostScript origin (0,0) at the LL corner
+ *                    of the page
  * \param[in]    res resolution of the input image, in ppi; use 0 for default
  * \param[in]    scale scaling by printer; use 0.0 or 1.0 for no scaling
  * \param[in]    pageno page number; must start with 1; you can use 0
@@ -1765,8 +1773,8 @@ L_COMP_DATA  *cid;
  * \param[in]    filein [optional] input filename; can be null
  * \param[in]    cid flate compressed image data
  * \param[in]    xpt, ypt location of LL corner of image, in pts, relative
- *                        to the PostScript origin (0,0 at the LL corner
- * \param[in]              of the page)
+ *                        to the PostScript origin (0,0) at the LL corner
+ *                        of the page
  * \param[in]    wpt, hpt rendered image size in pts
  * \param[in]    pageno page number; must start with 1; you can use 0
  *                      if there is only one page

--- a/src/ptafunc1.c
+++ b/src/ptafunc1.c
@@ -657,7 +657,7 @@ l_int32  i, j, n1, n2, x1, y1, x2, y2;
 /*!
  * \brief   ptaTransform()
  *
- * \param[in]    pta
+ * \param[in]    ptas
  * \param[in]    shiftx, shifty
  * \param[in]    scalex, scaley
  * \return  pta, or NULL on error

--- a/src/ptafunc2.c
+++ b/src/ptafunc2.c
@@ -582,8 +582,8 @@ PTA        *pta_small, *pta_big, *ptad;
  * \param[in]    pta
  * \param[in]    dahash built from pta
  * \param[in]    x, y  arbitrary points
- * \param[out]   pindex index into pta if (x,y is in pta;
- * \param[in]            -1 otherwise)
+ * \param[out]   pindex index into pta if (x,y) is in pta;
+ *                       -1 otherwise
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/ptra.c
+++ b/src/ptra.c
@@ -132,7 +132,7 @@ static l_int32 ptraExtendArray(L_PTRA *pa);
 /*!
  * \brief   ptraCreate()
  *
- * \param[in]    size of ptr array to be alloc'd 0 for default
+ * \param[in]    n size of ptr array to be alloc'd 0 for default
  * \return  pa, or NULL on error
  */
 L_PTRA *
@@ -161,21 +161,21 @@ L_PTRA  *pa;
 /*!
  * \brief   ptraDestroy()
  *
- * \param[in,out]   pptra to be nulled
- * \param[in]    freeflag TRUE to free each remaining item in the array
- * \param[in]    warnflag TRUE to warn if any remaining items are not destroyed
+ * \param[in,out]   ppa ptra to be nulled
+ * \param[in]       freeflag TRUE to free each remaining item in the array
+ * \param[in]       warnflag TRUE to warn if any remaining items are not destroyed
  * \return  void
  *
  * <pre>
  * Notes:
  *      (1) If %freeflag == TRUE, frees each item in the array.
- *      (2) If %freeflag == FALSE and warnflag == TRUE, and there are
+ *      (2) If %freeflag == FALSE and %warnflag == TRUE, and there are
  *          items on the array, this gives a warning and destroys the array.
  *          If these items are not owned elsewhere, this will cause
  *          a memory leak of all the items that were on the array.
  *          So if the items are not owned elsewhere and require their
  *          own destroy function, they must be destroyed before the ptra.
- *      (3) If warnflag == FALSE, no warnings will be issued.  This is
+ *      (3) If %warnflag == FALSE, no warnings will be issued.  This is
  *          useful if the items are owned elsewhere, such as a
  *          PixMemoryStore().
  *      (4) To destroy the ptra, we destroy the ptr array, then
@@ -226,7 +226,7 @@ L_PTRA  *pa;
 /*!
  * \brief   ptraAdd()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[in]    item  generic ptr to a struct
  * \return  0 if OK, 1 on error
  *
@@ -265,7 +265,7 @@ l_int32  imax;
 /*!
  * \brief   ptraExtendArray()
  *
- * \param[in]    ptra
+ * \param[in]    pa
  * \return  0 if OK, 1 on error
  */
 static l_int32
@@ -289,7 +289,7 @@ ptraExtendArray(L_PTRA  *pa)
 /*!
  * \brief   ptraInsert()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[in]    index location in ptra to insert new value
  * \param[in]    item  generic ptr to a struct; can be null
  * \param[in]    shiftflag L_AUTO_DOWNSHIFT, L_MIN_DOWNSHIFT, L_FULL_DOWNSHIFT
@@ -414,7 +414,7 @@ l_float32  nexpected;
 /*!
  * \brief   ptraRemove()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[in]    index element to be removed
  * \param[in]    flag L_NO_COMPACTION, L_COMPACTION
  * \return  item, or NULL on error
@@ -477,7 +477,7 @@ void    *item;
 /*!
  * \brief   ptraRemoveLast()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \return  item, or NULL on error or if the array is empty
  */
 void *
@@ -502,7 +502,7 @@ l_int32  imax;
 /*!
  * \brief   ptraReplace()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[in]    index element to be replaced
  * \param[in]    item  new generic ptr to a struct; can be null
  * \param[in]    freeflag TRUE to free old item; FALSE to return it
@@ -545,7 +545,7 @@ void    *olditem;
 /*!
  * \brief   ptraSwap()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[in]    index1
  * \param[in]    index2
  * \return  0 if OK, 1 on error
@@ -578,7 +578,7 @@ void    *item;
 /*!
  * \brief   ptraCompactArray()
  *
- * \param[in]    ptra
+ * \param[in]    pa
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -619,7 +619,7 @@ l_int32  i, imax, nactual, index;
 /*!
  * \brief   ptraReverse()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \return  0 if OK, 1 on error
  */
 l_int32
@@ -642,8 +642,8 @@ l_int32  i, imax;
 /*!
  * \brief   ptraJoin()
  *
- * \param[in]    ptra1 add to this one
- * \param[in]    ptra2 appended to ptra1, and emptied of items; can be null
+ * \param[in]    pa1 add to this one
+ * \param[in]    pa2 appended to pa1, and emptied of items; can be null
  * \return  0 if OK, 1 on error
  */
 l_int32
@@ -677,7 +677,7 @@ void    *item;
 /*!
  * \brief   ptraGetMaxIndex()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[out]   pmaxindex index of last item in the array;
  * \return  0 if OK; 1 on error
  *
@@ -714,7 +714,7 @@ ptraGetMaxIndex(L_PTRA   *pa,
 /*!
  * \brief   ptraGetActualCount()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[out]   pcount actual number of items on the ptr array
  * \return  0 if OK; 1 on error
  *
@@ -743,7 +743,7 @@ ptraGetActualCount(L_PTRA   *pa,
 /*!
  * \brief   ptraGetPtrToItem()
  *
- * \param[in]    ptra
+ * \param[in]    pa ptra
  * \param[in]    index of element to be retrieved
  * \return  a ptr to the element, or NULL on error
  *
@@ -778,7 +778,7 @@ ptraGetPtrToItem(L_PTRA  *pa,
 /*!
  * \brief   ptraaCreate()
  *
- * \param[in]    size of ptr array to be alloc'd
+ * \param[in]    n size of ptr array to be alloc'd
  * \return  paa, or NULL on error
  *
  * <pre>
@@ -859,7 +859,7 @@ L_PTRAA  *paa;
 /*!
  * \brief   ptraaGetSize()
  *
- * \param[in]    ptraa
+ * \param[in]    paa
  * \param[out]   psize size of ptr array
  * \return  0 if OK; 1 on error
  */
@@ -882,9 +882,9 @@ ptraaGetSize(L_PTRAA  *paa,
 /*!
  * \brief   ptraaInsertPtra()
  *
- * \param[in]    ptraa
+ * \param[in]    paa ptraa
  * \param[in]    index location in array for insertion
- * \param[in]    ptra to be inserted
+ * \param[in]    pa to be inserted
  * \return  0 if OK; 1 on error
  *
  * <pre>
@@ -921,7 +921,7 @@ l_int32  n;
 /*!
  * \brief   ptraaGetPtra()
  *
- * \param[in]    ptraa
+ * \param[in]    paa ptraa
  * \param[in]    index location in array
  * \param[in]    accessflag L_HANDLE_ONLY, L_REMOVE
  * \return  ptra at index location, or NULL on error or if there
@@ -968,7 +968,7 @@ L_PTRA  *pa;
 /*!
  * \brief   ptraaFlattenToPtra()
  *
- * \param[in]    ptraa
+ * \param[in]    paa ptraa
  * \return  ptra, or NULL on error
  *
  * <pre>

--- a/src/quadtree.c
+++ b/src/quadtree.c
@@ -246,7 +246,7 @@ DPIX      *dpix_msac;  /* msa clone */
 /*!
  * \brief   pixMeanInRectangle()
  *
- * \param[in]    pix 8 bpp
+ * \param[in]    pixs 8 bpp
  * \param[in]    box region to compute mean value
  * \param[in]    pixma mean accumulator
  * \param[out]   pval mean value
@@ -319,7 +319,7 @@ BOX       *boxc;
 /*!
  * \brief   pixVarianceInRectangle()
  *
- * \param[in]    pix 8 bpp
+ * \param[in]    pixs 8 bpp
  * \param[in]    box region to compute variance and/or root variance
  * \param[in]    pix_ma mean accumulator
  * \param[in]    dpix_msa mean square accumulator
@@ -555,7 +555,7 @@ l_int32  n;
  *
  * \param[in]    fpixa mean, variance or root variance
  * \param[in]    level, x, y of current pixel
- * \param[out]   pval00, val01, val10, val11  child pixel values
+ * \param[out]   pval00, pval01, pval10, pval11  child pixel values
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/queue.c
+++ b/src/queue.c
@@ -78,7 +78,7 @@ static l_int32 lqueueExtendArray(L_QUEUE *lq);
 /*!
  * \brief   lqueueCreate()
  *
- * \param[in]    size of ptr array to be alloc'd 0 for default
+ * \param[in]    nalloc size of ptr array to be alloc'd 0 for default
  * \return  lqueue, or NULL on error
  *
  * <pre>
@@ -109,7 +109,7 @@ L_QUEUE  *lq;
 /*!
  * \brief   lqueueDestroy()
  *
- * \param[in,out]   plqueue  to be nulled
+ * \param[in,out]   plq to be nulled
  * \param[in]    freeflag TRUE to free each remaining struct in the array
  * \return  void
  *
@@ -168,7 +168,7 @@ L_QUEUE  *lq;
 /*!
  * \brief   lqueueAdd()
  *
- * \param[in]    lqueue
+ * \param[in]    lq lqueue
  * \param[in]    item to be added to the tail of the queue
  * \return  0 if OK, 1 on error
  *
@@ -215,7 +215,7 @@ lqueueAdd(L_QUEUE  *lq,
 /*!
  * \brief   lqueueExtendArray()
  *
- * \param[in]    lqueue
+ * \param[in]    lq lqueue
  * \return  0 if OK, 1 on error
  */
 static l_int32
@@ -239,7 +239,7 @@ lqueueExtendArray(L_QUEUE  *lq)
 /*!
  * \brief   lqueueRemove()
  *
- * \param[in]    lqueue
+ * \param[in]    lq lqueue
  * \return  ptr to item popped from the head of the queue,
  *              or NULL if the queue is empty or on error
  *
@@ -275,7 +275,7 @@ void  *item;
 /*!
  * \brief   lqueueGetCount()
  *
- * \param[in]    lqueue
+ * \param[in]    lq lqueue
  * \return  count, or 0 on error
  */
 l_int32
@@ -297,7 +297,7 @@ lqueueGetCount(L_QUEUE  *lq)
  * \brief   lqueuePrint()
  *
  * \param[in]    fp file stream
- * \param[in]    lqueue
+ * \param[in]    lq lqueue
  * \return  0 if OK; 1 on error
  */
 l_int32

--- a/src/readfile.c
+++ b/src/readfile.c
@@ -140,7 +140,7 @@ SARRAY  *sa;
 /*!
  * \brief   pixaReadFilesSA()
  *
- * \param[in]    sarray full pathnames for all files
+ * \param[in]    sa full pathnames for all files
  * \return  pixa, or NULL on error
  */
 PIXA *
@@ -246,7 +246,7 @@ PIX   *pix;
 /*!
  * \brief   pixReadIndexed()
  *
- * \param[in]    sarray of full pathnames
+ * \param[in]    sa string array of full pathnames
  * \param[in]    index into pathname array
  * \return  pix if OK; null if not found
  *
@@ -621,7 +621,7 @@ l_int32  format;
 /*!
  * \brief   findFileFormatBuffer()
  *
- * \param[in]    byte buffer at least 12 bytes in size; we can't check
+ * \param[in]    buf byte buffer at least 12 bytes in size; we can't check
  * \param[out]   pformat found format
  * \return  0 if OK, 1 on error or if format is not recognized
  *
@@ -770,7 +770,7 @@ l_int32  format;
  * \brief   pixReadMem()
  *
  * \param[in]    data const; encoded
- * \param[in]    datasize size of data
+ * \param[in]    size size of data
  * \return  pix, or NULL on error
  *
  * <pre>
@@ -878,7 +878,7 @@ PIX     *pix;
  * \brief   pixReadHeaderMem()
  *
  * \param[in]    data const; encoded
- * \param[in]    datasize size of data
+ * \param[in]    size size of data
  * \param[out]   pformat [optional] image format
  * \param[out]   pw, ph [optional] width and height
  * \param[out]   pbps [optional] bits/sample

--- a/src/recogbasic.c
+++ b/src/recogbasic.c
@@ -392,8 +392,8 @@ recogaExtendArray(L_RECOGA  *recoga)
 /*!
  * \brief   recogReplaceInRecoga()
  *
- * \param[in]    &recog1 old recog, to be destroyed
- * \param[in]    recog2 new recog, to be inserted in place of %recog1
+ * \param[in,out]  precog1 old recog, to be destroyed
+ * \param[in]      recog2 new recog, to be inserted in place of %recog1
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -512,7 +512,7 @@ recogGetCount(L_RECOG  *recog)
  * \brief   recogGetIndex()
  *
  * \param[in]    recog
- * \param[in]   &index into the parent recoga; -1 if no parent
+ * \param[out]   pindex into the parent recoga; -1 if no parent
  * \return  0 if OK, 1 on error
  */
 l_int32
@@ -1506,7 +1506,6 @@ PIXA  *pixa;
 /*!
  * \brief   recogAddCharstrLabels()
  *
- * \param[in]    filename
  * \param[in]    recog
  * \return  0 if OK, 1 on error
  */

--- a/src/recogident.c
+++ b/src/recogident.c
@@ -439,7 +439,7 @@ PIX     *pix, *pix1, *pix2;
  * \param[in]    recog with LUT's pre-computed
  * \param[in]    pixs typically of multiple touching characters, 1 bpp
  * \param[out]   pboxa bounding boxs of best fit character
- * \param[out]   pnascores [optional] correlation scores
+ * \param[out]   pnascore [optional] correlation scores
  * \param[out]   pnaindex [optional] indices of classes
  * \param[out]   psachar [optional] array of character strings
  * \param[in]    debug 1 for results written to pixadb_split
@@ -1293,8 +1293,7 @@ L_RCHA  *rcha;
 /*!
  * \brief   rchaDestroy()
  *
- * \param[in]    &rcha
- * \return  void
+ * \param[in,out]  prcha to be nulled
  */
 void
 rchaDestroy(L_RCHA  **prcha)
@@ -1368,8 +1367,7 @@ L_RCH  *rch;
 /*!
  * \brief   rchDestroy()
  *
- * \param[in]    &rch
- * \return  void
+ * \param[in,out] prch to be nulled
  */
 void
 rchDestroy(L_RCH  **prch)
@@ -2074,7 +2072,7 @@ recogSetScaling(L_RECOG  *recog,
 /*!
  * \brief   l_showIndicatorSplitValues()
  *
- * \param[in]    6 indicator array
+ * \param[in]  na1, na2, na3, na4, na5, na6  6 indicator array
  *
  * <pre>
  * Notes:

--- a/src/recogtrain.c
+++ b/src/recogtrain.c
@@ -613,9 +613,9 @@ PTA       *ptat;
  *
  * \param[in]    pixa of samples from the same class, 1 bpp
  * \param[in]    pta [optional] of centroids of the samples
- * \param[out]   pppixd accumulated samples, 8 bpp
- * \param[out]   ppx [optional] average x coordinate of centroids
- * \param[out]   ppy [optional] average y coordinate of centroids
+ * \param[out]   ppixd accumulated samples, 8 bpp
+ * \param[out]   px [optional] average x coordinate of centroids
+ * \param[out]   py [optional] average y coordinate of centroids
  * \return  0 on success, 1 on failure
  *
  * <pre>
@@ -1175,9 +1175,9 @@ PIXA      *pixa, *pixaf;
 /*!
  * \brief   recogPadTrainingSet()
  *
- * \param[in]    &recog to be replaced if padding or more drastic measures
- *                      are necessary; otherwise, it is unchanged.
- * \param[in]    debug 1 for debug output saved to recog; 0 otherwise
+ * \param[in,out]  precog to be replaced if padding or more drastic measures
+ *                        are necessary; otherwise, it is unchanged.
+ * \param[in]      debug 1 for debug output saved to recog; 0 otherwise
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -1558,7 +1558,7 @@ PIXA    *pixa;
  * \param[out]   pnaset of indices into the sets to be matched
  * \param[out]   pnaindex of matching indices into the best set
  * \param[out]   pnascore of best correlation scores
- * \param[out]   pnaave average of correlation scores from each recog
+ * \param[out]   pnasum average of correlation scores from each recog
  * \param[in]    pixadb [optional] debug images; use NULL for no debug
  * \return  0 if OK, 1 on error
  *
@@ -1765,7 +1765,6 @@ PIXA      *pixa1;
  * \param[in]    bootpath [optional] path to single bootstrap labelled pixa
  * \param[in]    boot_iters number of 2x2 erosions for extension of boot pixa
  * \param[in]    type character set type; -1 for default; see enum in recog.h
- * \param[in]    size character set size; -1 for default
  * \param[in]    min_nopad min number in a class without padding; -1 default
  * \param[in]    max_afterpad max number of samples in padded classes;
  *                            -1 for default

--- a/src/rotateam.c
+++ b/src/rotateam.c
@@ -338,7 +338,7 @@ PIX      *pixt1, *pixt2, *pixd;
  *
  * \param[in]    pixs
  * \param[in]    angle radians; clockwise is positive
- * \param[in]    colorval e.g., 0 to bring in BLACK, 0xffffff00 for WHITE
+ * \param[in]    fillval e.g., 0 to bring in BLACK, 0xffffff00 for WHITE
  * \return  pixd, or NULL on error
  *
  * <pre>

--- a/src/sarray1.c
+++ b/src/sarray1.c
@@ -149,8 +149,8 @@ static l_int32 sarrayExtendArray(SARRAY *sa);
 /*!
  * \brief   sarrayCreate()
  *
- * \param[in]    size of string ptr array to be alloc'd
- * \param[in]    use 0 for default
+ * \param[in]    n size of string ptr array to be alloc'd;
+ *               use 0 for default
  * \return  sarray, or NULL on error
  */
 SARRAY *
@@ -371,7 +371,7 @@ SARRAY  *sa;
 /*!
  * \brief   sarrayCopy()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  copy of sarray, or NULL on error
  */
 SARRAY *
@@ -398,7 +398,7 @@ SARRAY  *csa;
 /*!
  * \brief   sarrayClone()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  ptr to same sarray, or NULL on error
  */
 SARRAY *
@@ -416,7 +416,7 @@ sarrayClone(SARRAY  *sa)
 /*!
  * \brief   sarrayAddString()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[in]    string  string to be added
  * \param[in]    copyflag L_INSERT, L_COPY
  * \return  0 if OK, 1 on error
@@ -463,7 +463,7 @@ l_int32  n;
 /*!
  * \brief   sarrayExtendArray()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  0 if OK, 1 on error
  */
 static l_int32
@@ -487,7 +487,7 @@ sarrayExtendArray(SARRAY  *sa)
 /*!
  * \brief   sarrayRemoveString()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[in]    index of string within sarray
  * \return  removed string, or NULL on error
  */
@@ -527,7 +527,7 @@ l_int32  i, n, nalloc;
 /*!
  * \brief   sarrayReplaceString()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[in]    index of string within sarray to be replaced
  * \param[in]    newstr string to replace existing one
  * \param[in]    copyflag L_INSERT, L_COPY
@@ -576,7 +576,7 @@ l_int32  n;
 /*!
  * \brief   sarrayClear()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  0 if OK; 1 on error
  */
 l_int32
@@ -603,7 +603,7 @@ l_int32  i;
 /*!
  * \brief   sarrayGetCount()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  count, or 0 if no strings or on error
  */
 l_int32
@@ -620,7 +620,7 @@ sarrayGetCount(SARRAY  *sa)
 /*!
  * \brief   sarrayGetArray()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[out]   pnalloc  [optional] number allocated string ptrs
  * \param[out]   pn  [optional] number allocated strings
  * \return  ptr to string array, or NULL on error
@@ -654,7 +654,7 @@ char  **array;
 /*!
  * \brief   sarrayGetString()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[in]    index   to the index-th string
  * \param[in]    copyflag  L_NOCOPY or L_COPY
  * \return  string, or NULL on error
@@ -697,7 +697,7 @@ sarrayGetString(SARRAY  *sa,
 /*!
  * \brief   sarrayGetRefCount()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  refcount, or UNDEF on error
  */
 l_int32
@@ -714,7 +714,7 @@ sarrayGetRefcount(SARRAY  *sa)
 /*!
  * \brief   sarrayChangeRefCount()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[in]    delta change to be applied
  * \return  0 if OK, 1 on error
  */
@@ -737,7 +737,7 @@ sarrayChangeRefcount(SARRAY  *sa,
 /*!
  * \brief   sarrayToString()
  *
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \param[in]    addnlflag flag: 0 adds nothing to each substring
  *                               1 adds '\n' to each substring
  *                               2 adds ' ' to each substring
@@ -771,7 +771,7 @@ sarrayToString(SARRAY  *sa,
 /*!
  * \brief   sarrayToStringRange()
  *
- * \param[in]   sarray
+ * \param[in]   sa string array
  * \param[in]   first  index of first string to use; starts with 0
  * \param[in]   nstrings number of strings to append into the result; use
  *                       0 to append to the end of the sarray
@@ -1434,7 +1434,7 @@ SARRAY  *sa;
  * \brief   sarrayWrite()
  *
  * \param[in]    filename
- * \param[in]    sarray
+ * \param[in]    sa string array
  * \return  0 if OK; 1 on error
  */
 l_int32
@@ -1465,8 +1465,8 @@ FILE  *fp;
  * \brief   sarrayWriteStream()
  *
  * \param[in]    fp file stream
- * \param[in]    sa
- * \param[in]  s 0 if OK; 1 on error
+ * \param[in]    sa string array
+ * \return  0 if OK; 1 on error
  *
  * <pre>
  * Notes:
@@ -1537,7 +1537,7 @@ FILE  *fp;
 /*!
  * \brief   getNumberedPathnamesInDirectory()
  *
- * \param[in]    directory name
+ * \param[in]    dirname directory name
  * \param[in]    substr [optional] substring filter on filenames; can be NULL
  * \param[in]    numpre number of characters in name before number
  * \param[in]    numpost number of characters in name after the number,
@@ -1603,7 +1603,7 @@ SARRAY  *sa, *saout;
 /*!
  * \brief   getSortedPathnamesInDirectory()
  *
- * \param[in]    directory name
+ * \param[in]    dirname directory name
  * \param[in]    substr [optional] substring filter on filenames; can be NULL
  * \param[in]    first 0-based
  * \param[in]    nfiles use 0 for all to the end
@@ -1667,7 +1667,7 @@ SARRAY  *sa, *safiles, *saout;
 /*!
  * \brief   convertSortedToNumberedPathnames()
  *
- * \param[in]    sorted pathnames including zero-padded integers
+ * \param[in]    sa sorted pathnames including zero-padded integers
  * \param[in]    numpre number of characters in name before number
  * \param[in]    numpost number of characters in name after the number,
  *                       up to a dot before an extension
@@ -1734,7 +1734,7 @@ SARRAY  *saout;
 /*!
  * \brief   getFilenamesInDirectory()
  *
- * \param[in]    directory name
+ * \param[in]    dirname directory name
  * \return  sarray of file names, or NULL on error
  *
  * <pre>

--- a/src/scale.c
+++ b/src/scale.c
@@ -1164,7 +1164,7 @@ PIX       *pixd;
 /*!
  * \brief   pixScaleSmooth()
  *
- * \param[in]    pixs 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
+ * \param[in]    pix 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
  * \param[in]    scalex, scaley must both be < 0.7
  * \return  pixd, or NULL on error
  *
@@ -1318,7 +1318,7 @@ PIX       *pixd;
 /*!
  * \brief   pixScaleAreaMap()
  *
- * \param[in]    pixs 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
+ * \param[in]    pix 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
  * \param[in]    scalex, scaley must both be <= 0.7
  * \return  pixd, or NULL on error
  *
@@ -1442,7 +1442,7 @@ PIX       *pixs, *pixd, *pixt1, *pixt2, *pixt3;
 /*!
  * \brief   pixScaleAreaMap2()
  *
- * \param[in]    pixs 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
+ * \param[in]    pix 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
  * \return  pixd, or NULL on error
  *
  * <pre>

--- a/src/scalelow.c
+++ b/src/scalelow.c
@@ -1665,7 +1665,11 @@ l_float32  wratio, hratio;
 /*!
  * \brief   scaleToGray2Low()
  *
- * \param[in]    usual image variables
+ * \param[in]    datad   dest data
+ * \param[in]    wd, hd  dest width, height
+ * \param[in]    wpld    dest words/line
+ * \param[in]    datas   src data
+ * \param[in]    wpls    src words/line
  * \param[in]    sumtab  made from makeSumTabSG2()
  * \param[in]    valtab  made from makeValTabSG2()
  * \return  0 if OK; 1 on error.
@@ -1795,7 +1799,11 @@ l_uint8  *tab;
 /*!
  * \brief   scaleToGray3Low()
  *
- * \param[in]    usual image variables
+ * \param[in]    datad   dest data
+ * \param[in]    wd, hd  dest width, height
+ * \param[in]    wpld    dest words/line
+ * \param[in]    datas   src data
+ * \param[in]    wpls    src words/line
  * \param[in]    sumtab  made from makeSumTabSG3()
  * \param[in]    valtab  made from makeValTabSG3()
  * \return  0 if OK; 1 on error
@@ -1952,7 +1960,11 @@ l_uint8  *tab;
 /*!
  * \brief   scaleToGray4Low()
  *
- * \param[in]    usual image variables
+ * \param[in]    datad   dest data
+ * \param[in]    wd, hd  dest width, height
+ * \param[in]    wpld    dest words/line
+ * \param[in]    datas   src data
+ * \param[in]    wpls    src words/line
  * \param[in]    sumtab  made from makeSumTabSG4()
  * \param[in]    valtab  made from makeValTabSG4()
  * \return  0 if OK; 1 on error.
@@ -2070,7 +2082,11 @@ l_uint8  *tab;
 /*!
  * \brief   scaleToGray6Low()
  *
- * \param[in]    usual image variables
+ * \param[in]    datad   dest data
+ * \param[in]    wd, hd  dest width, height
+ * \param[in]    wpld    dest words/line
+ * \param[in]    datas   src data
+ * \param[in]    wpls    src words/line
  * \param[in]    tab8  made from makePixelSumTab8()
  * \param[in]    valtab  made from makeValTabSG6()
  * \return  0 if OK; 1 on error
@@ -2217,7 +2233,11 @@ l_uint8  *tab;
 /*!
  * \brief   scaleToGray8Low()
  *
- * \param[in]    usual image variables
+ * \param[in]    datad   dest data
+ * \param[in]    wd, hd  dest width, height
+ * \param[in]    wpld    dest words/line
+ * \param[in]    datas   src data
+ * \param[in]    wpls    src words/line
  * \param[in]    tab8  made from makePixelSumTab8()
  * \param[in]    valtab  made from makeValTabSG8()
  * \return  0 if OK; 1 on error.
@@ -2304,8 +2324,12 @@ l_uint8  *tab;
 /*!
  * \brief   scaleToGray16Low()
  *
- * \param[in]    usual image variables
- * \param[in]    tab8  made from makePixelSumTab8()
+ * \param[in]    datad   dest data
+ * \param[in]    wd, hd  dest width, height
+ * \param[in]    wpld    dest words/line
+ * \param[in]    datas   src data
+ * \param[in]    wpls    src words/line
+ * \param[in]    tab8    made from makePixelSumTab8()
  * \return  0 if OK; 1 on error.
  *
  *  The output is processed one dest byte at a time, corresponding

--- a/src/seedfill.c
+++ b/src/seedfill.c
@@ -400,7 +400,7 @@ PIX  *pixsi, *pixd;
  * \brief   pixFillClosedBorders()
  *
  * \param[in]    pixs 1 bpp
- * \param[in]    filling connectivity 4 or 8
+ * \param[in]    connectivity filling connectivity 4 or 8
  * \return  pixd  all topologically outer closed borders are filled
  *                     as connected comonents, or NULL on error
  *
@@ -450,9 +450,9 @@ PIX  *pixsi, *pixd;
  * \brief   pixExtractBorderConnComps()
  *
  * \param[in]    pixs 1 bpp
- * \param[in]    filling connectivity 4 or 8
+ * \param[in]    connectivity filling connectivity 4 or 8
  * \return  pixd  all pixels in the src that are in connected
- *                     components touching the border, or NULL on error
+ *                components touching the border, or NULL on error
  */
 PIX *
 pixExtractBorderConnComps(PIX     *pixs,
@@ -484,9 +484,9 @@ PIX  *pixd;
  * \brief   pixRemoveBorderConnComps()
  *
  * \param[in]    pixs 1 bpp
- * \param[in]    filling connectivity 4 or 8
+ * \param[in]    connectivity filling connectivity 4 or 8
  * \return  pixd  all pixels in the src that are not touching the
- *                     border or NULL on error
+ *                border or NULL on error
  *
  * <pre>
  * Notes:
@@ -520,9 +520,9 @@ PIX  *pixd;
  * \brief   pixFillBgFromBorder()
  *
  * \param[in]    pixs 1 bpp
- * \param[in]    filling connectivity 4 or 8
+ * \param[in]    connectivity filling connectivity 4 or 8
  * \return  pixd with the background c.c. touching the border
- *                    filled to foreground, or NULL on error
+ *               filled to foreground, or NULL on error
  *
  * <pre>
  * Notes:
@@ -532,14 +532,15 @@ PIX  *pixd;
  *          This can be done multiple times, extracting holes within
  *          holes after each pair of fillings.  Specifically, this code
  *          peels away n successive embeddings of components:
- *              pix1 = \<initial image\>
- *              for (i = 0; i \< 2 * n; i++) {
+ * \code
+ *              pix1 = <initial image>
+ *              for (i = 0; i < 2 * n; i++) {
  *                   pix2 = pixFillBgFromBorder(pix1, 8);
  *                   pixInvert(pix2, pix2);
- *                   pixDestroy(\&pix1);
+ *                   pixDestroy(&pix1);
  *                   pix1 = pix2;
  *              }
-
+ * \endcode
  * </pre>
  */
 PIX *
@@ -1195,8 +1196,8 @@ PIX       *pixm, *pixt, *pixg, *pixd;
  *                      use 0 for default which is to have no upper bound
  * \param[in]    minmax min allowed for the max in a 3x3 neighborhood;
  *                      use 0 for default which is to have no lower bound
- * \param[out]   pppixmin [optional] mask of local minima
- * \param[out]   pppixmax [optional] mask of local maxima
+ * \param[out]   ppixmin [optional] mask of local minima
+ * \param[out]   ppixmax [optional] mask of local maxima
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -1369,8 +1370,8 @@ PIXA      *pixa;
  *
  * \param[in]    pixs  8 bpp
  * \param[in]    mindist -1 for keeping all pixels; >= 0 specifies distance
- * \param[out]   pppixmin mask of local minima
- * \param[out]   pppixmax mask of local maxima
+ * \param[out]   ppixmin mask of local minima
+ * \param[out]   ppixmax mask of local maxima
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/sel1.c
+++ b/src/sel1.c
@@ -398,9 +398,9 @@ SEL     *csel;
 /*!
  * \brief   selCreateBrick()
  *
- * \param[in]    height, width
+ * \param[in]    h, w    height, width
  * \param[in]    cy, cx  origin, relative to UL corner at 0,0
- * \param[in]    type  SEL_HIT, SEL_MISS, or SEL_DONT_CARE
+ * \param[in]    type    SEL_HIT, SEL_MISS, or SEL_DONT_CARE
  * \return  sel, or NULL on error
  *
  * <pre>
@@ -635,7 +635,7 @@ selaGetCount(SELA  *sela)
  * \brief   selaGetSel()
  *
  * \param[in]    sela
- * \param[in]    index of sel to be retrieved not copied
+ * \param[in]    i index of sel to be retrieved not copied
  * \return  sel, or NULL on error
  *
  * <pre>
@@ -707,9 +707,9 @@ selSetName(SEL         *sel,
  * \brief   selaFindSelByName()
  *
  * \param[in]    sela
- * \param[in]    sel name
- * \param[in]    &index <optional, return>
- * \param[in]    &sel  <optional, return> sel (not a copy)
+ * \param[in]    name sel name
+ * \param[out]   pindex [optional]
+ * \param[in]    psel   [optional] sel (not a copy)
  * \return  0 if OK; 1 on error
  */
 l_int32
@@ -1287,7 +1287,7 @@ SEL     *seld;
 /*!
  * \brief   selaRead()
  *
- * \param[in]    filename
+ * \param[in]    fname filename
  * \return  sela, or NULL on error
  */
 SELA  *
@@ -1354,7 +1354,7 @@ SELA    *sela;
 /*!
  * \brief   selRead()
  *
- * \param[in]    filename
+ * \param[in]    fname filename
  * \return  sel, or NULL on error
  */
 SEL  *
@@ -1431,7 +1431,7 @@ SEL     *sel;
 /*!
  * \brief   selaWrite()
  *
- * \param[in]    filename
+ * \param[in]    fname filename
  * \param[in]    sela
  * \return  0 if OK, 1 on error
  */
@@ -1493,7 +1493,7 @@ SEL     *sel;
 /*!
  * \brief   selWrite()
  *
- * \param[in]    filename
+ * \param[in]    fname filename
  * \param[in]    sel
  * \return  0 if OK, 1 on error
  */
@@ -1562,8 +1562,8 @@ l_int32  sx, sy, cx, cy, i, j;
  * \brief   selCreateFromString()
  *
  * \param[in]    text
- * \param[in]    height, width
- * \param[in]    name [optional] sel name; can be null
+ * \param[in]    h, w  height, width
+ * \param[in]    name  [optional] sel name; can be null
  * \return  sel of the given size, or NULL on error
  *
  * <pre>
@@ -1577,10 +1577,12 @@ l_int32  sx, sy, cx, cy, i, j;
  *          When the origin falls on a don't-care, use 'C' as the uppecase
  *          for ' '.
  *      (3) The text can be input in a format that shows the 2D layout; e.g.,
+ * \code
  *              static const char *seltext = "x    "
  *                                           "x Oo "
  *                                           "x    "
  *                                           "xxxxx";
+ * \endcode
  * </pre>
  */
 SEL *

--- a/src/selgen.c
+++ b/src/selgen.c
@@ -96,7 +96,7 @@ static const l_int32  MAX_SEL_SCALEFACTOR = 31;  /* should be big enough */
 /*!
  * \brief   pixGenerateSelWithRuns()
  *
- * \param[in]    pix 1 bpp, typically small, to be used as a pattern
+ * \param[in]    pixs 1 bpp, typically small, to be used as a pattern
  * \param[in]    nhlines number of hor lines along which elements are found
  * \param[in]    nvlines number of vert lines along which elements are found
  * \param[in]    distance min distance from boundary pixel; use 0 for default
@@ -302,7 +302,7 @@ SEL       *seld, *sel;
 /*!
  * \brief   pixGenerateSelRandom()
  *
- * \param[in]    pix 1 bpp, typically small, to be used as a pattern
+ * \param[in]    pixs 1 bpp, typically small, to be used as a pattern
  * \param[in]    hitfract fraction of allowable fg pixels that are hits
  * \param[in]    missfract fraction of allowable bg pixels that are misses
  * \param[in]    distance min distance from boundary pixel; use 0 for default
@@ -447,7 +447,7 @@ SEL       *seld, *sel;
 /*!
  * \brief   pixGenerateSelBoundary()
  *
- * \param[in]    pix 1 bpp, typically small, to be used as a pattern
+ * \param[in]    pixs 1 bpp, typically small, to be used as a pattern
  * \param[in]    hitdist min distance from fg boundary pixel
  * \param[in]    missdist min distance from bg boundary pixel
  * \param[in]    hitskip number of boundary pixels skipped between hits
@@ -854,7 +854,7 @@ PTA     *pta;
  *
  * \param[in]    pixs 1 bpp
  * \param[in]    x, y current pixel
- * \param[in]    xa, ya adjacent ON pixel, found by simple CCW search
+ * \param[out]   pxa, pya adjacent ON pixel, found by simple CCW search
  * \return  1 if a pixel is found; 0 otherwise or on error
  *
  * <pre>

--- a/src/shear.c
+++ b/src/shear.c
@@ -77,7 +77,7 @@ static l_float32 normalizeAngleForShear(l_float32 radang, l_float32 mindif);
  *                    or different from pixs
  * \param[in]    pixs no restrictions on depth
  * \param[in]    yloc location of horizontal line, measured from origin
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd, always
  *
@@ -194,7 +194,7 @@ l_float32  tanangle, invangle;
  *                    or different from pixs
  * \param[in]    pixs no restrictions on depth
  * \param[in]    xloc location of vertical line, measured from origin
- * \param[in]    angle in radians; not too close to +-(pi / 2)
+ * \param[in]    radang  angle in radians; not too close to +-(pi / 2)
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd, or NULL on error
  *
@@ -313,7 +313,7 @@ l_float32  tanangle, invangle;
  *
  * \param[in]    pixd [optional], if not null, must be equal to pixs
  * \param[in]    pixs
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd, or NULL on error.
  *
@@ -344,7 +344,7 @@ pixHShearCorner(PIX       *pixd,
  *
  * \param[in]    pixd [optional], if not null, must be equal to pixs
  * \param[in]    pixs
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd, or NULL on error.
  *
@@ -375,7 +375,7 @@ pixVShearCorner(PIX       *pixd,
  *
  * \param[in]    pixd [optional], if not null, must be equal to pixs
  * \param[in]    pixs
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd, or NULL on error.
  *
@@ -406,7 +406,7 @@ pixHShearCenter(PIX       *pixd,
  *
  * \param[in]    pixd [optional], if not null, must be equal to pixs
  * \param[in]    pixs
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd, or NULL on error.
  *
@@ -441,7 +441,7 @@ pixVShearCenter(PIX       *pixd,
  *
  * \param[in]    pixs
  * \param[in]    yloc location of horizontal line, measured from origin
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  0 if OK; 1 on error
  *
@@ -516,7 +516,7 @@ l_float32  tanangle, invangle;
  *
  * \param[in]    pixs all depths; not colormapped
  * \param[in]    xloc  location of vertical line, measured from origin
- * \param[in]    angle in radians
+ * \param[in]    radang  angle in radians
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  0 if OK; 1 on error
  *
@@ -594,7 +594,7 @@ l_float32  tanangle, invangle;
  *
  * \param[in]    pixs 8 bpp or 32 bpp, or colormapped
  * \param[in]    yloc location of horizontal line, measured from origin
- * \param[in]    angle in radians, in range (-pi/2 ... pi/2)
+ * \param[in]    radang  angle in radians, in range (-pi/2 ... pi/2)
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd sheared, or NULL on error
  *
@@ -706,7 +706,7 @@ PIX       *pix, *pixd;
  *
  * \param[in]    pixs 8 bpp or 32 bpp, or colormapped
  * \param[in]    xloc  location of vertical line, measured from origin
- * \param[in]    angle in radians, in range (-pi/2 ... pi/2)
+ * \param[in]    radang  angle in radians, in range (-pi/2 ... pi/2)
  * \param[in]    incolor L_BRING_IN_WHITE, L_BRING_IN_BLACK;
  * \return  pixd sheared, or NULL on error
  *

--- a/src/stringcode.c
+++ b/src/stringcode.c
@@ -175,7 +175,7 @@ L_STRCODE  *strcode;
 /*!
  * \brief   strcodeDestroy()
  *
- * \param[in]    &strcode strcode is set to null after destroying the sarrays
+ * \param[out]  pstrcode &strcode is set to null after destroying the sarrays
  * \return  void
  */
 static void
@@ -327,8 +327,8 @@ l_int32  itype;
 /*!
  * \brief   strcodeFinalize()
  *
- * \param[in]   &strcode destroys after .c and .h files have been generated
- * \param[in]    outdir [optional] if null, files are made in /tmp/lept/auto
+ * \param[in,out]  pstrcode destroys after .c and .h files have been generated
+ * \param[in]      outdir [optional] if NULL, files are made in /tmp/lept/auto
  * \return  void
  */
 l_int32
@@ -588,7 +588,7 @@ l_int32  i, found;
 /*!
  * \brief   l_getIndexFromStructname()
  *
- * \param[in]    structname e.g., "Pixa"
+ * \param[in]    sn structname e.g., "Pixa"
  * \param[out]   pindex found index
  * \return  0 if found, 1 if not.
  *

--- a/src/sudoku.c
+++ b/src/sudoku.c
@@ -365,7 +365,7 @@ L_SUDOKU  *sud;
 /*!
  * \brief   sudokuSolve()
  *
- * \param[in]    l_sudoku starting in initial state
+ * \param[in]    sud l_sudoku starting in initial state
  * \return  1 on success, 0 on failure to solve note reversal of
  *              typical unix returns
  */
@@ -432,7 +432,7 @@ l_int32  i;
 /*!
  * \brief   sudokuNewGuess()
  *
- * \param[in]    l_sudoku
+ * \param[in]    sud l_sudoku
  * \return  0 if OK; 1 if no solution is possible
  *
  * <pre>
@@ -548,7 +548,7 @@ l_int32  blockrow, blockcol, blockstart, rowindex, locindex;
  * \brief   sudokuTestUniqueness()
  *
  * \param[in]    array of 81 numbers, 9 lines of 9 numbers each
- * \param[out]   ppunique 1 if unique, 0 if not
+ * \param[out]   punique 1 if unique, 0 if not
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -842,7 +842,7 @@ L_SUDOKU  *sud, *testsud;
 /*!
  * \brief   sudokuOutput()
  *
- * \param[in]    l_sudoku at any stage
+ * \param[in]    sud l_sudoku at any stage
  * \param[in]    arraytype L_SUDOKU_INIT, L_SUDOKU_STATE
  * \return  void
  *

--- a/src/textops.c
+++ b/src/textops.c
@@ -612,7 +612,7 @@ PIXCMAP  *cmap;
  *
  * \param[in]    pixas input pixa; colormap ok
  * \param[in]    bmf bitmap font data
- * \param[in]    numa [optional] number array; use 1 ... n if null
+ * \param[in]    na [optional] number array; use 1 ... n if null
  * \param[in]    val color to set the text
  * \param[in]    location L_ADD_ABOVE, L_ADD_BELOW, L_ADD_LEFT, L_ADD_RIGHT
  * \return  pixad new pixa with rendered numbers, or NULL on error
@@ -1006,8 +1006,8 @@ l_int32  i, w, width, nchar;
 /*!
  * \brief   splitStringToParagraphs()
  *
- * \param[in]    textstring
- * \param[in]    splitting flag see enum in bmf.h; valid values in {1,2,3}
+ * \param[in]    textstr text string
+ * \param[in]    splitflag see enum in bmf.h; valid values in {1,2,3}
  * \return  sarray where each string is a paragraph of the input,
  *                      or NULL on error.
  */
@@ -1057,7 +1057,7 @@ SARRAY  *salines, *satemp, *saout;
 /*!
  * \brief   stringAllWhitespace()
  *
- * \param[in]    textstring
+ * \param[in]    textstr text string
  * \param[out]   pval 1 if all whitespace; 0 otherwise
  * \return  0 if OK, 1 on error
  */
@@ -1089,8 +1089,8 @@ l_int32  len, i;
 /*!
  * \brief   stringLeadingWhitespace()
  *
- * \param[in]    textstring
- * \param[out]   pval 1 if leading char is ' ' or '\t'; 0 otherwise
+ * \param[in]    textstr text string
+ * \param[out]   pval 1 if leading char is [space] or [tab]; 0 otherwise
  * \return  0 if OK, 1 on error
  */
 static l_int32

--- a/src/tiffio.c
+++ b/src/tiffio.c
@@ -340,7 +340,7 @@ lept_size_proc(thandle_t  cookie)
  * \brief   pixReadTiff()
  *
  * \param[in]    filename
- * \param[in]    page number 0 based
+ * \param[in]    n page number 0 based
  * \return  pix, or NULL on error
  *
  * <pre>
@@ -657,8 +657,8 @@ pixWriteTiff(const char  *filename,
  * \param[in]    filename to write to
  * \param[in]    pix
  * \param[in]    comptype IFF_TIFF, IFF_TIFF_RLE, IFF_TIFF_PACKBITS,
- *                        IFF_TIFF_G3, IFF_TIFF_G4
- * \param[in]              IFF_TIFF_LZW, IFF_TIFF_ZIP)
+ *                        IFF_TIFF_G3, IFF_TIFF_G4,
+ *                        IFF_TIFF_LZW, IFF_TIFF_ZIP
  * \param[in]    modestring "a" or "w"
  * \param[in]    natags [optional] NUMA of custom tiff tags
  * \param[in]    savals [optional] SARRAY of values
@@ -1207,7 +1207,7 @@ SARRAY  *sa;
 /*!
  * \brief   writeMultipageTiffSA()
  *
- * \param[in]    sarray of full path names
+ * \param[in]    sa string array of full path names
  * \param[in]    fileout output ps file
  * \return  0 if OK, 1 on error
  *
@@ -2231,8 +2231,8 @@ L_MEMSTREAM  *mstream;
 /*!
  * \brief   pixReadMemTiff()
  *
- * \param[in]    data const; tiff-encoded
- * \param[in]    datasize size of data
+ * \param[in]    cdata const; tiff-encoded
+ * \param[in]    size size of cdata
  * \param[in]    n page image number: 0-based
  * \return  pix, or NULL on error
  *

--- a/src/utils.c
+++ b/src/utils.c
@@ -537,7 +537,7 @@ l_int32  lendest, lensrc;
  * \brief   stringConcatNew()
  *
  * \param[in]    first first string in list
- * \param[in]    varargs  NULL-terminated list of strings
+ * \param[in]    ...  NULL-terminated list of strings
  * \return  result new string concatenating the input strings, or
  *                      NULL if first == NULL
  *
@@ -621,8 +621,8 @@ l_int32  srclen1, srclen2, destlen;
 /*!
  * \brief   stringJoinIP()
  *
- * \param[in]    &src1 string address of src1; cannot be on the stack
- * \param[in]    src2 string [optional] can be null
+ * \param[in,out]  psrc1 string address of src1; cannot be on the stack
+ * \param[in]      src2 string [optional] can be null
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -639,10 +639,12 @@ l_int32  srclen1, srclen2, destlen;
  *          Then call with:
  *              stringJoinIP(\&src1, src2);
  *      (4) This can also be implemented as a macro:
+ * \code
  *              #define stringJoinIP(src1, src2) \
  *                  {tmpstr = stringJoin((src1),(src2)); \
  *                  LEPT_FREE(src1); \
  *                  (src1) = tmpstr;}
+ * \endcode
  *      (5) Another function to consider for joining many strings is
  *          stringConcatNew().
  * </pre>
@@ -1003,7 +1005,7 @@ l_int32  nsrc, nsub1, nsub2, len, npre, loc;
  * \param[in]    src input string; can be of zero length
  * \param[in]    sub1 substring to be replaced
  * \param[in]    sub2 substring to put in; can be ""
- * \param[in]    &count <optional return > the number of times that sub1
+ * \param[out]   pcount [optional] the number of times that sub1
  *                      is found in src; 0 if not found
  * \return  dest string with substring replaced, or NULL if the
  *              substring not found or on error.
@@ -1113,7 +1115,7 @@ L_DNA   *da;
  * \param[in]    datalen length of data, in bytes
  * \param[in]    sequence subarray of bytes to find in data
  * \param[in]    seqlen length of sequence, in bytes
- * \param[in]    &offset return> offset from beginning of
+ * \param[out]   poffset offset from beginning of
  *                       data where the sequence begins
  * \param[out]   pfound 1 if sequence is found; 0 otherwise
  * \return  0 if OK, 1 on error
@@ -1176,9 +1178,9 @@ l_int32  i, j, found, lastpos;
 /*!
  * \brief   reallocNew()
  *
- * \param[in]    &indata [optional]; nulls indata
- * \param[in]    oldsize size of input data to be copied, in bytes
- * \param[in]    newsize size of data to be reallocated in bytes
+ * \param[in,out]  pindata [optional]; nulls indata
+ * \param[in]      oldsize size of input data to be copied, in bytes
+ * \param[in]      newsize size of data to be reallocated in bytes
  * \return  ptr to new data, or NULL on error
  *
  *  Action: !N.B. 3) and (4!
@@ -2068,8 +2070,7 @@ lept_calloc(size_t  nmemb,
 /*!
  * \brief   lept_free()
  *
- * \param[in]    void ptr
- * \return  0 if OK, 1 on error
+ * \param[in]    ptr
  *
  * <pre>
  * Notes:
@@ -3026,7 +3027,7 @@ l_int32  dirlen, namelen, size;
  *
  * \param[in]    result preallocated on stack or heap and passed in
  * \param[in]    nbytes size of %result array, in bytes
- * \param[in]    subdirs [optional]; can be NULL or an empty string
+ * \param[in]    subdir [optional]; can be NULL or an empty string
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -3035,12 +3036,14 @@ l_int32  dirlen, namelen, size;
  *          written into %result with unix separators.
  *      (2) Caller allocates %result, large enough to hold the path,
  *          which is:
- *            /tmp/%subdirs       (unix)
- *            \<Temp\>/%subdirs     (windows)
+ *            /tmp/%subdir       (unix)
+ *            \<Temp\>/%subdir     (windows)
  *          where \<Temp\> is a path on windows determined by GenTempPath().
  *      (3) Usage example:
+ * \code
  *           char  result[256];
  *           makeTempDirname(result, 256, "lept/golden");
+ * \endcode
  * </pre>
  */
 l_int32
@@ -3391,7 +3394,7 @@ l_uint8  *data;
  *
  * \param[in]    range size of range; must be >= 2
  * \param[in]    seed use 0 to skip; otherwise call srand
- * \param[out]   val random integer in range {0 ... range-1}
+ * \param[out]   pval random integer in range {0 ... range-1}
  * \return  0 if OK, 1 on error
  *
  * <pre>
@@ -3708,7 +3711,7 @@ convertBinaryToGrayCode(l_uint32 val)
 /*!
  * \brief   convertGrayCodeToBinary()
  *
- * \param[in]    gray code value
+ * \param[in]    val gray code value
  * \return  binary value
  */
 l_uint32
@@ -3852,8 +3855,8 @@ struct rusage  rusage_stop;
 /*!
  * \brief   l_getCurrentTime()
  *
- * \param[out]   psec [optional] in seconds since birth of Unix
- * \param[out]   pusec [optional] in microseconds since birth of Unix
+ * \param[out]   sec [optional] in seconds since birth of Unix
+ * \param[out]   usec [optional] in microseconds since birth of Unix
  * \return  void
  */
 void
@@ -3973,12 +3976,8 @@ LONGLONG        usecs;
 
 /*!
  * \brief   startWallTimer()
- * \param[in]    void
- * \return  walltimer-ptr
  *
- *  stopWallTimer
- *      Input:  &walltimer-ptr
- *      Return: time wall time elapsed in seconds
+ * \return  walltimer-ptr
  *
  * <pre>
  * Notes:
@@ -3999,6 +3998,12 @@ L_WALLTIMER  *timer;
     return timer;
 }
 
+/*!
+ * \brief   stopWallTimer()
+ *
+ * \param[in,out]  ptimer walltimer-ptr
+ * \return  time wall time elapsed in seconds
+ */
 l_float32
 stopWallTimer(L_WALLTIMER  **ptimer)
 {
@@ -4025,7 +4030,6 @@ L_WALLTIMER  *timer;
 /*!
  * \brief   l_getFormattedDate()
  *
- * \param[in]    none
  * \return  formatted date string, or NULL on error
  *
  * <pre>

--- a/src/viewfiles.c
+++ b/src/viewfiles.c
@@ -53,14 +53,14 @@ static const l_int32  MIN_VIEW_WIDTH = 300;
 /*!
  * \brief   pixHtmlViewer()
  *
- * \param[in]    dirin:  directory of input image files
- * \param[in]    dirout: directory for output files
- * \param[in]    rootname: root name for output files
- * \param[in]    thumbwidth:  width of thumb images
- * \param[in]                 in pixels; use 0 for default
- * \param[in]    viewwidth:  maximum width of view images no up-scaling
- * \param[in]                 in pixels; use 0 for default
- * \param[in]    copyorig:  1 to copy originals to dirout; 0 otherwise
+ * \param[in]    dirin      directory of input image files
+ * \param[in]    dirout     directory for output files
+ * \param[in]    rootname   root name for output files
+ * \param[in]    thumbwidth width of thumb images
+ *                          in pixels; use 0 for default
+ * \param[in]    viewwidth  maximum width of view images no up-scaling
+ *                          in pixels; use 0 for default
+ * \param[in]    copyorig   1 to copy originals to dirout; 0 otherwise
  * \return  0 if OK; 1 on error
  *
  * <pre>

--- a/src/warper.c
+++ b/src/warper.c
@@ -502,12 +502,12 @@ l_float32  twopi, invtwopi, findex, diff;
  *                    quadratic curvature out of the image plane
  * \param[in]    zshiftt uniform pixel translation difference between
  *                      red and cyan, that pushes the top of the image
- *                      plane away from the viewer (zshiftt > 0 or
- * \param[in]            towards the viewer zshiftt < 0)
+ *                      plane away from the viewer (zshiftt > 0) or
+ *                      towards the viewer (zshiftt < 0)
  * \param[in]    zshiftb uniform pixel translation difference between
  *                      red and cyan, that pushes the bottom of the image
- *                      plane away from the viewer (zshiftb > 0 or
- * \param[in]            towards the viewer zshiftb < 0)
+ *                      plane away from the viewer (zshiftb > 0) or
+ *                      towards the viewer (zshiftb < 0)
  * \param[in]    ybendt multiplicative parameter for in-plane vertical
  *                      displacement at the left or right edge at the top:
  *                        y = ybendt * (2x/w - 1)^2


### PR DESCRIPTION
Fix all remaining param warnings and conversion bugs.
Now 'doxygen.log' should contain only warnings for
missing documentation for functions, enums, variables etc.