### PR TITLE
Remove Autotools build of src/xtractprotos to fix #179

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@
 makefile
 Makefile
 Makefile.in
-xtractprotos
 /aclocal.m4
 /autom4te.cache
 /config/

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,7 +73,6 @@ pkginclude_HEADERS = allheaders.h alltypes.h                    \
  readbarcode.h recog.h regutils.h stack.h                       \
  stringcode.h sudoku.h watershed.h
 
-noinst_PROGRAMS = xtractprotos
 LDADD = liblept.la
 
 EXTRA_DIST = arrayaccess.h.vc                                   \
@@ -82,7 +81,8 @@ EXTRA_DIST = arrayaccess.h.vc                                   \
  morphtemplate1.txt morphtemplate2.txt                          \
  stringtemplate1.txt stringtemplate2.txt
 
-allheaders: $(liblept_la_SOURCES)
-	@test -x xtractprotos || echo "First run 'make xtractprotos'"
-	./xtractprotos -prestring=LEPT_DLL -protos=inline $(liblept_la_SOURCES)
+$(top_builddir)/prog/xtractprotos$(EXEEXT): liblept.la
+	$(MAKE) -C $(top_builddir)/prog xtractprotos$(EXEEXT)
 
+allheaders: $(top_builddir)/prog/xtractprotos$(EXEEXT) $(liblept_la_SOURCES)
+	cd $(srcdir) && $(abs_top_builddir)/prog/xtractprotos$(EXEEXT) -prestring=LEPT_DLL -protos=inline $(liblept_la_SOURCES)


### PR DESCRIPTION
The allheaders target now triggers a build of xtractprotos in the prog directory. I'm not sure if this is the proper way to do it but it's good enough to have the following work as expected.

```sh
./configure
cd src
make allheaders
```

I have assumed that allheaders.h should be written to the source directory rather than the build directory. Changing this would be difficult.

It doesn't work when building outside of the source tree but this was already broken. cpp, as invoked by xtractprotos, needs to locate endianness.h and this is written to the build directory. Perhaps xtractprotos should accept `-I` arguments or even pass all additional arguments to cpp.