### PR TITLE
Make float constants use float notation

### DIFF
--- a/src/baseline.c
+++ b/src/baseline.c
@@ -65,15 +65,15 @@ static const l_int32  ZERO_THRESHOLD_RATIO = 100;
 static const l_int32  DEFAULT_SLICES = 10;
 static const l_int32  DEFAULT_SWEEP_REDUCTION = 2;
 static const l_int32  DEFAULT_BS_REDUCTION = 1;
-static const l_float32  DEFAULT_SWEEP_RANGE = 5.;   /* degrees */
-static const l_float32  DEFAULT_SWEEP_DELTA = 1.;   /* degrees */
-static const l_float32  DEFAULT_MINBS_DELTA = 0.01;   /* degrees */
+static const l_float32  DEFAULT_SWEEP_RANGE = 5.f;   /* degrees */
+static const l_float32  DEFAULT_SWEEP_DELTA = 1.f;   /* degrees */
+static const l_float32  DEFAULT_MINBS_DELTA = 0.01f;   /* degrees */
 
     /* Overlap slice fraction added to top and bottom of each slice */
-static const l_float32  OVERLAP_FRACTION = 0.5;
+static const l_float32  OVERLAP_FRACTION = 0.5f;
 
     /* Minimum allowed confidence (ratio) for accepting a value */
-static const l_float32  MIN_ALLOWED_CONFIDENCE = 3.0;
+static const l_float32  MIN_ALLOWED_CONFIDENCE = 3.0f;
 
 
 /*---------------------------------------------------------------------*

--- a/src/bmf.c
+++ b/src/bmf.c
@@ -70,7 +70,7 @@
 #include "allheaders.h"
 #include "bmfdata.h"
 
-static const l_float32  VERT_FRACT_SEP = 0.3;
+static const l_float32  VERT_FRACT_SEP = 0.3f;
 
 #ifndef  NO_CONSOLE_IO
 #define  DEBUG_BASELINE     0

--- a/src/colorquant2.c
+++ b/src/colorquant2.c
@@ -224,7 +224,7 @@ static const l_int32  MAX_ITERS_ALLOWED = 5000;  /* prevents infinite looping */
 
     /* Specify fraction of vboxes made that are sorted on population alone.
      * The remaining vboxes are sorted on (population * vbox-volume).  */
-static const l_float32  FRACT_BY_POPULATION = 0.85;
+static const l_float32  FRACT_BY_POPULATION = 0.85f;
 
     /* To get the max value of 'dif' in the dithering color transfer,
      * divide DIF_CAP by 8. */

--- a/src/colorseg.c
+++ b/src/colorseg.c
@@ -45,7 +45,7 @@
 static const l_int32  MAX_ALLOWED_ITERATIONS = 20;
 
     /* Factor by which max dist is increased on each iteration */
-static const l_float32  DIST_EXPAND_FACT = 1.3;
+static const l_float32  DIST_EXPAND_FACT = 1.3f;
 
     /* Octcube division level for computing nearest colormap color using LUT.
      * Using 4 should suffice for up to 50 - 100 colors, and it is

--- a/src/compare.c
+++ b/src/compare.c
@@ -105,7 +105,7 @@
 #include "allheaders.h"
 
     /* Small enough to consider equal to 0.0, for plot output */
-static const l_float32  TINY = 0.00001;
+static const l_float32  TINY = 0.00001f;
 
 static l_int32 pixCompareTilesByHisto(PIX *pix1, PIX *pix2, l_int32 maxgray,
                                       l_int32 factor, l_int32 nx, l_int32 ny,

--- a/src/dewarp2.c
+++ b/src/dewarp2.c
@@ -80,7 +80,7 @@ static l_int32 pixRenderHorizEndPoints(PIX *pixs, PTA *ptal, PTA *ptar,
 #endif  /* !NO_CONSOLE_IO */
 
     /* Special parameter values */
-static const l_float32   MIN_RATIO_LINES_TO_HEIGHT = 0.45;
+static const l_float32   MIN_RATIO_LINES_TO_HEIGHT = 0.45f;
 
 
 /*----------------------------------------------------------------------*

--- a/src/enhance.c
+++ b/src/enhance.c
@@ -116,7 +116,7 @@
 
     /* Scales contrast enhancement factor to have a useful range
      * between 0.0 and 1.0 */
-static const l_float32  ENHANCE_SCALE_FACTOR = 5.;
+static const l_float32  ENHANCE_SCALE_FACTOR = 5.f;
 
     /* Default number of pixels sampled to determine histogram */
 static const l_int32  DEFAULT_HISTO_SAMPLES = 100000;

--- a/src/flipdetect.c
+++ b/src/flipdetect.c
@@ -194,12 +194,12 @@ static const char *textsel4 = "xxxxxx"
 
     /* Parameters for determining orientation */
 static const l_int32  DEFAULT_MIN_UP_DOWN_COUNT = 70;
-static const l_float32  DEFAULT_MIN_UP_DOWN_CONF = 7.0;
-static const l_float32  DEFAULT_MIN_UP_DOWN_RATIO = 2.5;
+static const l_float32  DEFAULT_MIN_UP_DOWN_CONF = 7.0f;
+static const l_float32  DEFAULT_MIN_UP_DOWN_RATIO = 2.5f;
 
     /* Parameters for determining mirror flip */
 static const l_int32  DEFAULT_MIN_MIRROR_FLIP_COUNT = 100;
-static const l_float32  DEFAULT_MIN_MIRROR_FLIP_CONF = 5.0;
+static const l_float32  DEFAULT_MIN_MIRROR_FLIP_CONF = 5.0f;
 
     /* Static debug function */
 static void pixDebugFlipDetect(const char *filename, PIX *pixs,

--- a/src/maze.c
+++ b/src/maze.c
@@ -68,8 +68,8 @@
 static const l_int32  MIN_MAZE_WIDTH = 50;
 static const l_int32  MIN_MAZE_HEIGHT = 50;
 
-static const l_float32  DEFAULT_WALL_PROBABILITY = 0.65;
-static const l_float32  DEFAULT_ANISOTROPY_RATIO = 0.25;
+static const l_float32  DEFAULT_WALL_PROBABILITY = 0.65f;
+static const l_float32  DEFAULT_ANISOTROPY_RATIO = 0.25f;
 
 enum {  /* direction from parent to newly created element */
     START_LOC = 0,

--- a/src/psio2.c
+++ b/src/psio2.c
@@ -107,7 +107,7 @@ static const l_int32  LETTER_WIDTH            = 612;   /* points */
 static const l_int32  LETTER_HEIGHT           = 792;   /* points */
 static const l_int32  A4_WIDTH                = 595;   /* points */
 static const l_int32  A4_HEIGHT               = 842;   /* points */
-static const l_float32  DEFAULT_FILL_FRACTION = 0.95;
+static const l_float32  DEFAULT_FILL_FRACTION = 0.95f;
 
 #ifndef  NO_CONSOLE_IO
 #define  DEBUG_JPEG       0

--- a/src/recogdid.c
+++ b/src/recogdid.c
@@ -166,7 +166,7 @@ static l_int32 recogGetWindowedArea(L_RECOG *recog, l_int32 index,
 static l_int32 recogTransferRchToDid(L_RECOG *recog, l_int32 x, l_int32 y);
 
     /* Parameters for modeling the decoding */
-static const l_float32  SetwidthFraction = 0.95;
+static const l_float32  SetwidthFraction = 0.95f;
 static const l_int32    MaxYShift = 1;
 
     /* Channel parameters.  alpha[0] is the probability that a bg pixel
@@ -175,8 +175,8 @@ static const l_int32    MaxYShift = 1;
      * than 0.5 and smaller than 1.0.  For more accuracy in template
      * matching, use a 4-level template, where levels 2 and 3 are
      * boundary pixels in the fg and bg, respectively. */
-static const l_float32  DefaultAlpha2[] = {0.95, 0.9};
-static const l_float32  DefaultAlpha4[] = {0.95, 0.9, 0.75, 0.25};
+static const l_float32  DefaultAlpha2[] = {0.95f, 0.9f};
+static const l_float32  DefaultAlpha4[] = {0.95f, 0.9f, 0.75f, 0.25f};
 
 
 /*------------------------------------------------------------------------*

--- a/src/recogident.c
+++ b/src/recogident.c
@@ -101,8 +101,8 @@
 static const l_int32    LeftRightPadding = 32;
 
     /* Parameters for filtering and sorting connected components in splitter */
-static const l_float32  MaxAspectRatio = 6.0;
-static const l_float32  MinFillFactor = 0.10;
+static const l_float32  MaxAspectRatio = 6.0f;
+static const l_float32  MinFillFactor = 0.10f;
 static const l_int32  MinOverlap1 = 6;  /* in pass 1 of boxaSort2d() */
 static const l_int32  MinOverlap2 = 6;  /* in pass 2 of boxaSort2d() */
 static const l_int32  MinHeightPass1 = 5;  /* min height to start pass 1 */

--- a/src/recogtrain.c
+++ b/src/recogtrain.c
@@ -88,8 +88,8 @@ static void debugAddImage2(PIXA *pixadb, PIXA *pixa1, L_BMF *bmf,
                            l_int32 index);
 
     /* Defaults in pixRemoveOutliers() */
-static const l_float32  DEFAULT_TARGET_SCORE = 0.75; /* keep everything above */
-static const l_float32  DEFAULT_MIN_FRACTION = 0.5;  /* to be kept */
+static const l_float32  DEFAULT_TARGET_SCORE = 0.75f; /* keep everything above */
+static const l_float32  DEFAULT_MIN_FRACTION = 0.5f;  /* to be kept */
 
     /* Padding parameters for recognizer */
 static const char *     DEFAULT_BOOT_DIR = "recog/digits";

--- a/src/rotate.c
+++ b/src/rotate.c
@@ -57,9 +57,9 @@
 #include "allheaders.h"
 
 extern l_float32  AlphaMaskBorderVals[2];
-static const l_float32  MIN_ANGLE_TO_ROTATE = 0.001;  /* radians; ~0.06 deg */
-static const l_float32  MAX_1BPP_SHEAR_ANGLE = 0.06;  /* radians; ~3 deg    */
-static const l_float32  LIMIT_SHEAR_ANGLE = 0.35;     /* radians; ~20 deg   */
+static const l_float32  MIN_ANGLE_TO_ROTATE = 0.001f;  /* radians; ~0.06 deg */
+static const l_float32  MAX_1BPP_SHEAR_ANGLE = 0.06f;  /* radians; ~3 deg    */
+static const l_float32  LIMIT_SHEAR_ANGLE = 0.35f;     /* radians; ~20 deg   */
 
 
 /*------------------------------------------------------------------*

--- a/src/rotateam.c
+++ b/src/rotateam.c
@@ -99,7 +99,7 @@
 #include <string.h>
 #include "allheaders.h"
 
-static const l_float32  MIN_ANGLE_TO_ROTATE = 0.001;  /* radians; ~0.06 deg */
+static const l_float32  MIN_ANGLE_TO_ROTATE = 0.001f;  /* radians; ~0.06 deg */
 
 
 /*------------------------------------------------------------------*

--- a/src/rotateshear.c
+++ b/src/rotateshear.c
@@ -164,9 +164,9 @@
 #include <string.h>
 #include "allheaders.h"
 
-static const l_float32  MIN_ANGLE_TO_ROTATE = 0.001;  /* radians; ~0.06 deg */
-static const l_float32  MAX_2_SHEAR_ANGLE = 0.06;     /* radians; ~3 deg    */
-static const l_float32  LIMIT_SHEAR_ANGLE = 0.35;     /* radians; ~20 deg   */
+static const l_float32  MIN_ANGLE_TO_ROTATE = 0.001f;  /* radians; ~0.06 deg */
+static const l_float32  MAX_2_SHEAR_ANGLE = 0.06f;     /* radians; ~3 deg    */
+static const l_float32  LIMIT_SHEAR_ANGLE = 0.35f;     /* radians; ~20 deg   */
 
 /*------------------------------------------------------------------*
  *                Rotations about an arbitrary point                *

--- a/src/shear.c
+++ b/src/shear.c
@@ -57,7 +57,7 @@
 #include "allheaders.h"
 
     /* Shear angle must not get too close to -pi/2 or pi/2 */
-static const l_float32   MIN_DIFF_FROM_HALF_PI = 0.04;
+static const l_float32   MIN_DIFF_FROM_HALF_PI = 0.04f;
 
 static l_float32 normalizeAngleForShear(l_float32 radang, l_float32 mindif);
 

--- a/src/skew.c
+++ b/src/skew.c
@@ -98,24 +98,24 @@
 #include "allheaders.h"
 
     /* Default sweep angle parameters for pixFindSkew() */
-static const l_float32  DEFAULT_SWEEP_RANGE = 7.;    /* degrees */
-static const l_float32  DEFAULT_SWEEP_DELTA = 1.;    /* degrees */
+static const l_float32  DEFAULT_SWEEP_RANGE = 7.f;    /* degrees */
+static const l_float32  DEFAULT_SWEEP_DELTA = 1.f;    /* degrees */
 
     /* Default final angle difference parameter for binary
      * search in pixFindSkew().  The expected accuracy is
      * not better than the inverse image width in pixels,
      * say, 1/2000 radians, or about 0.03 degrees. */
-static const l_float32  DEFAULT_MINBS_DELTA = 0.01;  /* degrees */
+static const l_float32  DEFAULT_MINBS_DELTA = 0.01f;  /* degrees */
 
     /* Default scale factors for pixFindSkew() */
 static const l_int32  DEFAULT_SWEEP_REDUCTION = 4;  /* sweep part; 4 is good */
 static const l_int32  DEFAULT_BS_REDUCTION = 2;  /* binary search part */
 
     /* Minimum angle for deskewing in pixDeskew() */
-static const l_float32  MIN_DESKEW_ANGLE = 0.1;  /* degree */
+static const l_float32  MIN_DESKEW_ANGLE = 0.1f;  /* degree */
 
     /* Minimum allowed confidence (ratio) for deskewing in pixDeskew() */
-static const l_float32  MIN_ALLOWED_CONFIDENCE = 3.0;
+static const l_float32  MIN_ALLOWED_CONFIDENCE = 3.0f;
 
     /* Minimum allowed maxscore to give nonzero confidence */
 static const l_int32  MIN_VALID_MAXSCORE = 10000;
@@ -123,7 +123,7 @@ static const l_int32  MIN_VALID_MAXSCORE = 10000;
     /* Constant setting threshold for minimum allowed minscore
      * to give nonzero confidence; multiply this constant by
      *  (height * width^2) */
-static const l_float32  MINSCORE_THRESHOLD_CONSTANT = 0.000002;
+static const l_float32  MINSCORE_THRESHOLD_CONSTANT = 0.000002f;
 
     /* Default binarization threshold value */
 static const l_int32  DEFAULT_BINARY_THRESHOLD = 130;

--- a/src/warper.c
+++ b/src/warper.c
@@ -76,9 +76,9 @@ static l_int32 applyWarpTransform(l_float32 xmag, l_float32 ymag,
 
     /* Suggested input to pixStereoFromPair().  These are weighting
      * factors for input to the red channel from the left image. */
-static const l_float32  L_DEFAULT_RED_WEIGHT   = 0.0;
-static const l_float32  L_DEFAULT_GREEN_WEIGHT = 0.7;
-static const l_float32  L_DEFAULT_BLUE_WEIGHT  = 0.3;
+static const l_float32  L_DEFAULT_RED_WEIGHT   = 0.0f;
+static const l_float32  L_DEFAULT_GREEN_WEIGHT = 0.7f;
+static const l_float32  L_DEFAULT_BLUE_WEIGHT  = 0.3f;
 
 
 /*----------------------------------------------------------------------*

--- a/src/writefile.c
+++ b/src/writefile.c
@@ -101,7 +101,7 @@ static const l_int32  MAX_DISPLAY_HEIGHT = 800;
 static const l_int32  MAX_SIZE_FOR_PNG = 200;
 
     /* PostScript output for printing */
-static const l_float32  DEFAULT_SCALING = 1.0;
+static const l_float32  DEFAULT_SCALING = 1.0f;
 
     /* Global array of image file format extension names.                */
     /* This is in 1-1 corrspondence with format enum in imageio.h.       */


### PR DESCRIPTION
Shut some compilers' useless warnings about a "possible loss of data"
when converting a double constant (0.1) to a float. Append "f" (0.1f).