### PR TITLE
pnmio: Add support for P7 format (PAM)

### DIFF
--- a/prog/pnmio_reg.c
+++ b/prog/pnmio_reg.c
@@ -37,7 +37,7 @@ l_int32 main(l_int32  argc,
              char   **argv)
 {
 FILE         *fp;
-PIX          *pix1, *pix2, *pix3, *pix4;
+PIX          *pix1, *pix2, *pix3, *pix4, *pix5;
 L_REGPARAMS  *rp;
 
     if (regTestSetup(argc, argv, &rp))
@@ -55,9 +55,16 @@ L_REGPARAMS  *rp;
     pixWrite("/tmp/lept/pnm/pix2.1.pnm", pix2, IFF_PNM);
     pix3 = pixRead("/tmp/lept/pnm/pix2.1.pnm");
     regTestComparePix(rp, pix1, pix3);  /* 0 */
+        /* write PAM */
+    fp = lept_fopen("/tmp/lept/pnm/pix3.1.pnm", "wb");
+    pixWriteStreamPam(fp, pix1);
+    lept_fclose(fp);
+    pix4 = pixRead("/tmp/lept/pnm/pix3.1.pnm");
+    regTestComparePix(rp, pix1, pix4);  /* 1 */
     pixDestroy(&pix1);
     pixDestroy(&pix2);
     pixDestroy(&pix3);
+    pixDestroy(&pix4);
 
         /* Test 2, 4 and 8 bpp (pgm) read/write */
     pix1 = pixRead("weasel8.png");
@@ -68,10 +75,17 @@ L_REGPARAMS  *rp;
     pix3 = pixRead("/tmp/lept/pnm/pix2.2.pnm");
     pixWrite("/tmp/lept/pnm/pix3.2.pnm", pix3, IFF_PNM);
     pix4 = pixRead("/tmp/lept/pnm/pix3.2.pnm");
-    regTestComparePix(rp, pix2, pix4);  /* 1 */
+    regTestComparePix(rp, pix2, pix4);  /* 2 */
+        /* write PAM */
+    fp = lept_fopen("/tmp/lept/pnm/pix4.2.pnm", "wb");
+    pixWriteStreamPam(fp, pix2);
+    lept_fclose(fp);
+    pix5 = pixRead("/tmp/lept/pnm/pix4.2.pnm");
+    regTestComparePix(rp, pix2, pix5);  /* 3 */
     pixDestroy(&pix2);
     pixDestroy(&pix3);
     pixDestroy(&pix4);
+    pixDestroy(&pix5);
 
     pix2 = pixThresholdTo4bpp(pix1, 16, 0);
     fp = lept_fopen("/tmp/lept/pnm/pix2.4.pnm", "wb");
@@ -80,10 +94,17 @@ L_REGPARAMS  *rp;
     pix3 = pixRead("/tmp/lept/pnm/pix2.4.pnm");
     pixWrite("/tmp/lept/pnm/pix3.4.pnm", pix3, IFF_PNM);
     pix4 = pixRead("/tmp/lept/pnm/pix3.4.pnm");
-    regTestComparePix(rp, pix2, pix4);  /* 2 */
+    regTestComparePix(rp, pix2, pix4);  /* 4 */
+        /* write PAM */
+    fp = lept_fopen("/tmp/lept/pnm/pix4.4.pnm", "wb");
+    pixWriteStreamPam(fp, pix2);
+    lept_fclose(fp);
+    pix5 = pixRead("/tmp/lept/pnm/pix4.4.pnm");
+    regTestComparePix(rp, pix2, pix5);  /* 5 */
     pixDestroy(&pix2);
     pixDestroy(&pix3);
     pixDestroy(&pix4);
+    pixDestroy(&pix5);
 
     fp = lept_fopen("/tmp/lept/pnm/pix1.8.pnm", "wb");
     pixWriteStreamAsciiPnm(fp, pix1);
@@ -91,10 +112,17 @@ L_REGPARAMS  *rp;
     pix2 = pixRead("/tmp/lept/pnm/pix1.8.pnm");
     pixWrite("/tmp/lept/pnm/pix2.8.pnm", pix2, IFF_PNM);
     pix3 = pixRead("/tmp/lept/pnm/pix2.8.pnm");
-    regTestComparePix(rp, pix1, pix3);  /* 3 */
+    regTestComparePix(rp, pix1, pix3);  /* 6 */
+        /* write PAM */
+    fp = lept_fopen("/tmp/lept/pnm/pix3.8.pnm", "wb");
+    pixWriteStreamPam(fp, pix1);
+    lept_fclose(fp);
+    pix4 = pixRead("/tmp/lept/pnm/pix3.8.pnm");
+    regTestComparePix(rp, pix1, pix4);  /* 7 */
     pixDestroy(&pix1);
     pixDestroy(&pix2);
     pixDestroy(&pix3);
+    pixDestroy(&pix4);
 
         /* Test ppm (24 bpp rgb) read/write */
     pix1 = pixRead("marge.jpg");
@@ -104,7 +132,27 @@ L_REGPARAMS  *rp;
     pix2 = pixRead("/tmp/lept/pnm/pix1.24.pnm");
     pixWrite("/tmp/lept/pnm/pix2.24.pnm", pix2, IFF_PNM);
     pix3 = pixRead("/tmp/lept/pnm/pix2.24.pnm");
-    regTestComparePix(rp, pix1, pix3);  /* 4 */
+    regTestComparePix(rp, pix1, pix3);  /* 8 */
+        /* write PAM */
+    fp = lept_fopen("/tmp/lept/pnm/pix3.24.pnm", "wb");
+    pixWriteStreamPam(fp, pix1);
+    lept_fclose(fp);
+    pix4 = pixRead("/tmp/lept/pnm/pix3.24.pnm");
+    regTestComparePix(rp, pix1, pix4);  /* 9 */
+    pixDestroy(&pix1);
+    pixDestroy(&pix2);
+    pixDestroy(&pix3);
+    pixDestroy(&pix4);
+
+        /* Test pam (32 bpp rgba) read/write */
+    pix1 = pixRead("test32-alpha.png");
+    fp = lept_fopen("/tmp/lept/pnm/pix1.32.pnm", "wb");
+    pixWriteStreamPam(fp, pix1);
+    lept_fclose(fp);
+    pix2 = pixRead("/tmp/lept/pnm/pix1.32.pnm");
+    pixWrite("/tmp/lept/pnm/pix2.32.pnm", pix2, IFF_PNM);
+    pix3 = pixRead("/tmp/lept/pnm/pix2.32.pnm");
+    regTestComparePix(rp, pix1, pix3);  /* 10 */
     pixDestroy(&pix1);
     pixDestroy(&pix2);
     pixDestroy(&pix3);

--- a/src/allheaders.h
+++ b/src/allheaders.h
@@ -1884,9 +1884,11 @@ LEPT_DLL extern l_int32 readHeaderPnm ( const char *filename, l_int32 *pw, l_int
 LEPT_DLL extern l_int32 freadHeaderPnm ( FILE *fp, l_int32 *pw, l_int32 *ph, l_int32 *pd, l_int32 *ptype, l_int32 *pbps, l_int32 *pspp );
 LEPT_DLL extern l_int32 pixWriteStreamPnm ( FILE *fp, PIX *pix );
 LEPT_DLL extern l_int32 pixWriteStreamAsciiPnm ( FILE *fp, PIX *pix );
+LEPT_DLL extern l_int32 pixWriteStreamPam ( FILE *fp, PIX *pix );
 LEPT_DLL extern PIX * pixReadMemPnm ( const l_uint8 *data, size_t size );
 LEPT_DLL extern l_int32 readHeaderMemPnm ( const l_uint8 *data, size_t size, l_int32 *pw, l_int32 *ph, l_int32 *pd, l_int32 *ptype, l_int32 *pbps, l_int32 *pspp );
 LEPT_DLL extern l_int32 pixWriteMemPnm ( l_uint8 **pdata, size_t *psize, PIX *pix );
+LEPT_DLL extern l_int32 pixWriteMemPam ( l_uint8 **pdata, size_t *psize, PIX *pix );
 LEPT_DLL extern PIX * pixProjectiveSampledPta ( PIX *pixs, PTA *ptad, PTA *ptas, l_int32 incolor );
 LEPT_DLL extern PIX * pixProjectiveSampled ( PIX *pixs, l_float32 *vc, l_int32 incolor );
 LEPT_DLL extern PIX * pixProjectivePta ( PIX *pixs, PTA *ptad, PTA *ptas, l_int32 incolor );

--- a/src/pnmiostub.c
+++ b/src/pnmiostub.c
@@ -76,6 +76,13 @@ l_int32 pixWriteStreamAsciiPnm(FILE *fp, PIX *pix)
 
 /* ----------------------------------------------------------------------*/
 
+l_int32 pixWriteStreamPam(FILE *fp, PIX *pix)
+{
+    return ERROR_INT("function not present", "pixWriteStreamPnm", 1);
+}
+
+/* ----------------------------------------------------------------------*/
+
 PIX * pixReadMemPnm(const l_uint8 *cdata, size_t size)
 {
     return (PIX * )ERROR_PTR("function not present", "pixReadMemPnm", NULL);
@@ -96,6 +103,13 @@ l_int32 pixWriteMemPnm(l_uint8 **pdata, size_t *psize, PIX *pix)
 {
     return ERROR_INT("function not present", "pixWriteMemPnm", 1);
 }
+/* ----------------------------------------------------------------------*/
+
+l_int32 pixWriteMemPam(l_uint8 **pdata, size_t *psize, PIX *pix)
+{
+    return ERROR_INT("function not present", "pixWriteMemPnm", 1);
+}
+
 
 /* --------------------------------------------*/
 #endif  /* !USE_PNMIO */

--- a/src/readfile.c
+++ b/src/readfile.c
@@ -663,7 +663,7 @@ l_uint16  twobytepw;
 
         /* Check for the p*m 2-byte header ids */
     if ((buf[0] == 'P' && buf[1] == '4') || /* newer packed */
-        (buf[0] == 'P' && buf[1] == '1')) {  /* old format */
+        (buf[0] == 'P' && buf[1] == '1')) {  /* old ASCII format */
         *pformat = IFF_PNM;
         return 0;
     }
@@ -676,6 +676,11 @@ l_uint16  twobytepw;
 
     if ((buf[0] == 'P' && buf[1] == '6') || /* newer */
         (buf[0] == 'P' && buf[1] == '3')) {  /* old */
+        *pformat = IFF_PNM;
+        return 0;
+    }
+
+    if (buf[0] == 'P' && buf[1] == '7') {  /* new arbitrary (PAM) */
         *pformat = IFF_PNM;
         return 0;
     }


### PR DESCRIPTION
The netpbm tools support a new "arbitrary" format.
See: http://netpbm.sourceforge.net/doc/pam.html

It is defined by the header "P7" followed a number of
lines with tags defining the attributes. The format
of the image data is always binary, as in P4, P5 and P6.

This format supports an optional alpha channel and
will be used automagically when a Pix with 32-bpp
and 4 samples per pixel is to be written by the
pixWriteStreamPnm() or pixWriteMemPnm() functions.

Not too many viewers do yet support this format.

For verifying and converting test images the netpbm tools
can be used. To create a sample 32 bpp rgba image do:
`pngtopam --alphapam test32-alpha.png >test32-alpha.pam`