### PR TITLE
snprintf is available in VS2015

### DIFF
--- a/src/environ.h
+++ b/src/environ.h
@@ -489,7 +489,7 @@ LEPT_DLL extern l_int32  LeptMsgSeverity;
 /*------------------------------------------------------------------------*
  *                        snprintf() renamed in MSVC                      *
  *------------------------------------------------------------------------*/
-#ifdef _MSC_VER
+#if defined _MSC_VER && _MSC_VER < 1900
 #define snprintf(buf, size, ...)  _snprintf_s(buf, size, _TRUNCATE, __VA_ARGS__)
 #endif
 


### PR DESCRIPTION
Starting with Visual Studio 2015 `snprintf` is available and the macro is no longer needed.