### PR TITLE
Add CPPAN support for windows builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # build directories
 /build*
+/cppan*
 /win*
 
 # files in prog without a .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,18 @@ if (WIN32)
     endif()
 endif()
 
+if(EXISTS ${PROJECT_SOURCE_DIR}/cppan)
+    add_subdirectory(cppan)
+    add_definitions(
+        -DHAVE_LIBGIF=1
+        -DHAVE_LIBJPEG=1
+        -DHAVE_LIBPNG=1
+        -DHAVE_LIBTIFF=1
+        -DHAVE_LIBWEBP=1
+        -DHAVE_LIBZ=1
+    )
+endif()
+
 ###############################################################################
 #
 # configure

--- a/cppan.yml
+++ b/cppan.yml
@@ -1,4 +1,3 @@
-host: https://cppan.org/
 dependencies:
   pvt.cppan.demo.gif: 5
   pvt.cppan.demo.jpeg: master

--- a/cppan.yml
+++ b/cppan.yml
@@ -1,0 +1,8 @@
+host: https://cppan.org/
+dependencies:
+  pvt.cppan.demo.gif: 5
+  pvt.cppan.demo.jpeg: master
+  pvt.cppan.demo.png: 1.6.21
+  pvt.cppan.demo.tiff: master
+  pvt.cppan.demo.webp: "*"
+  pvt.cppan.demo.zlib: 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ if (UNIX)
 endif()
 
 if (NOT USE_CPPAN)
-    export(TARGETS leptonica APPEND FILE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake)
+    export(TARGETS leptonica FILE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake)
 else()
     target_link_libraries       (leptonica cppan)
     file(WRITE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake "include(${CMAKE_BINARY_DIR}/cppan.cmake)\n")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 if (NOT STATIC)
     target_compile_definitions  (leptonica PRIVATE -DLIBLEPT_EXPORTS)
 endif()
+
 if (GIF_LIBRARY)
     target_link_libraries       (leptonica ${GIF_LIBRARY})
 endif()
@@ -46,10 +47,18 @@ endif()
 if (ZLIB_LIBRARY)
     target_link_libraries       (leptonica ${ZLIB_LIBRARY})
 endif()
+
 if (UNIX)
     target_link_libraries       (leptonica m)
 endif()
-export(TARGETS leptonica FILE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake)
+
+if (NOT USE_CPPAN)
+    export(TARGETS leptonica APPEND FILE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake)
+else()
+    target_link_libraries       (leptonica cppan)
+    file(WRITE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake "include(${CMAKE_BINARY_DIR}/cppan.cmake)\n")
+    export(TARGETS leptonica APPEND FILE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake)
+endif()
 
 ################################################################################
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ if (UNIX)
     target_link_libraries       (leptonica m)
 endif()
 
-if (NOT USE_CPPAN)
+if (NOT USES_CPPAN)
     export(TARGETS leptonica FILE ${CMAKE_BINARY_DIR}/LeptonicaTargets.cmake)
 else()
     target_link_libraries       (leptonica cppan)


### PR DESCRIPTION
Hi Dan,

I propose to add support of CPPAN (C++ Archive Network) for Windows build with dependencies. CPPAN is developed by me, now it's in alpha stage (but works pretty good). It's a C/C++ source package (packet) manager like CPAN (perl), CTAN (TeX) or CRAN (R-language). https://cppan.org/

Changes are quite small: one new file and couple of changes in CMakeLists.txt files that do not touch any existing build. CPPAN is activated only when 'cppan' command is invoked before build etc.

Such change is requested in #192.