### PR TITLE
psio: Fix double free

### DIFF
--- a/src/psio2.c
+++ b/src/psio2.c
@@ -1466,7 +1466,6 @@ FILE      *fp;
 
     for (i = 0; i < npages; i++) {
         if ((pix = pixReadTiff(filein, i)) == NULL) {
-            LEPT_FREE(tempfile);
             return ERROR_INT("pix not made", procName, 1);
         }
 


### PR DESCRIPTION
Coverity report:

CID 1365497 (#1 of 1): Double free (USE_AFTER_FREE)
18. double_free: Calling free frees pointer tempfile
which has already been freed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>