### PR TITLE
files_reg: Fix use after free

### DIFF
--- a/prog/files_reg.c
+++ b/prog/files_reg.c
@@ -212,7 +212,6 @@ SARRAY  *sa;
     lept_cp(srctail, newdir, newtail, &fname);
     if (rp->display)
         fprintf(stderr, "  File copied to: %s\n", fname);
-    lept_free(fname);
 
         /* move it elsewhere ... */
     lept_rmdir("junko");  /* clear out this directory */


### PR DESCRIPTION
Coverity report:

CID 1365496 (#1 of 2): Use after free (USE_AFTER_FREE)
7. pass_freed_arg: Passing freed pointer fname as an argument to fprintf

CID 1365496 (#2 of 2): Use after free (USE_AFTER_FREE)
8. pass_freed_arg: Passing freed pointer fname as an argument to fprintf

Signed-off-by: Stefan Weil <sw@weilnetz.de>