### PR TITLE
colorquant1: Remove wrong call of pixDestroy

### DIFF
--- a/src/colorquant1.c
+++ b/src/colorquant1.c
@@ -2306,7 +2306,6 @@ PIXCMAP   *cmap;
         nbase = 64;
         nextra = maxcolors - nbase;
     } else {
-        pixDestroy(&pixd);
         return (PIX *)ERROR_PTR("maxcolors not in {8...256}", procName, NULL);
     }
 


### PR DESCRIPTION
This fixes a new error reported by Coverity:

CID 1368189 (#1 of 1): Uninitialized pointer read (UNINIT)

Signed-off-by: Stefan Weil <sw@weilnetz.de>