### PR TITLE
added missing include dir for templated sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ include(Configure)
 
 configure_file(${AUTOCONFIG_SRC} ${AUTOCONFIG} @ONLY)
 
-set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src)
+set(INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src" "${CMAKE_CURRENT_BINARY_DIR}/src")
 
 configure_file(
     ${CMAKE_SOURCE_DIR}/cmake/templates/LeptonicaConfig-version.cmake.in


### PR DESCRIPTION
LeptonicaConfig.cmake (in build dir) was missing the include reference to the "src" folder inside the build directory. In my case another project wasn't able to find "endianness.h" which resides in that folder.

This build request adds the missing include directory inside the build dir to the include path.