### PR TITLE
prog/iotest: Fix potential negative array index read

### DIFF
--- a/prog/iotest.c
+++ b/prog/iotest.c
@@ -180,8 +180,9 @@ static char  mainName[] = "iotest";
 
         /* Other fields in the pix */
     format = pixGetInputFormat(pixs);
-    fprintf(stderr, "Input format extension: %s\n",
-            ImageFileFormatExtensions[format]);
+    if (format != UNDEF)
+        fprintf(stderr, "Input format extension: %s\n",
+                ImageFileFormatExtensions[format]);
     pixSetText(pixs, "reconstituted 4-bit weasel");
     text = pixGetText(pixs);
     if (text && strlen(text) != 0)


### PR DESCRIPTION
Coverity scan report:

CID 1364926 (#1 of 1): Negative array index read (NEGATIVE_RETURNS)

Signed-off-by: Stefan Weil <sw@weilnetz.de>