### PR TITLE
Handle $TMPDIR when located under /tmp

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -2986,23 +2986,24 @@ l_int32  dirlen, namelen, size;
         stringCopy(pathout, cdir, dirlen);
     } else {  /* in /tmp */
             /* Start with the temp dir */
+        l_int32 tmpdirlen;
 #ifdef _WIN32
-        l_int32 len;
         char tmpdir[MAX_PATH];
         GetTempPath(sizeof(tmpdir), tmpdir);  /* get the windows temp dir */
-        len = strlen(tmpdir);
-        if (len > 0 && tmpdir[len - 1] == '\\') {
-            tmpdir[len - 1] = '\0';  /* trim the trailing '\' */
+        tmpdirlen = strlen(tmpdir);
+        if (tmpdirlen > 0 && tmpdir[tmpdirlen - 1] == '\\') {
+            tmpdir[tmpdirlen - 1] = '\0';  /* trim the trailing '\' */
         }
 #else  /* unix */
         const char *tmpdir = getenv("TMPDIR");
         if (tmpdir == NULL) tmpdir = "/tmp";
+        tmpdirlen = strlen(tmpdir);
 #endif  /* _WIN32 */
-        stringCopy(pathout, tmpdir, strlen(tmpdir));
+        stringCopy(pathout, tmpdir, tmpdirlen);
 
-            /* Add the rest of cdir */
-        if (dirlen > 4)
-            stringCat(pathout, size, cdir + 4);
+       /* Add the rest of cdir */
+        if (dirlen > tmpdirlen)
+            stringCat(pathout, size, cdir + tmpdirlen);
     }
 
        /* Now handle %fname */


### PR DESCRIPTION
When adding the remainder of the cdir string to give the full value of pathout in genPathname(), the current code hardcodes a $TMPDIR string length of 4 characters (src/utils.c, lines 3004-5).

The result of this hardcoding is that the function will re-append any additional characters in the $TMPDIR string beyond "/tmp" into the pathout string when determining its full contents.

This causes failures when trying to open and write to files in $TMPDIR on Debian (and possibly other Linux distributions) that do not use plain /tmp as $TMPDIR for an unprivileged user. On Debian, a regular user's $TMPDIR is /tmp/username, not /tmp.

This commit aims to ensure that the full $TMPDIR string length is used and that only nested path entries below $TMPDIR (and not "/tmp") are appended when determining pathout.

Diagnosed using strace after failures running tesseract-ocr and gscan2pdf. No failures were observed when running as the superuser; strace confirmed the issue was broken pathnames and not r/w privileges.