### PR TITLE
Avoid some buffer overruns caused by very long file names

### DIFF
--- a/src/fhmtauto.c
+++ b/src/fhmtauto.c
@@ -395,7 +395,7 @@ SARRAY  *sa1, *sa2, *sa3;
         return ERROR_INT("filestr from sa3 not made", procName, 1);
     nbytes = strlen(filestr);
     if (filename)
-        sprintf(bigbuf, "%s.%d.c", filename, fileindex);
+        snprintf(bigbuf, L_BUF_SIZE, "%s.%d.c", filename, fileindex);
     else
         sprintf(bigbuf, "%s.%d.c", OUTROOT, fileindex);
     l_binaryWrite(bigbuf, "w", filestr, nbytes);
@@ -597,7 +597,7 @@ SEL     *sel;
         return ERROR_INT("filestr from sa4 not made", procName, 1);
     nbytes = strlen(filestr);
     if (filename)
-        sprintf(bigbuf, "%slow.%d.c", filename, fileindex);
+        snprintf(bigbuf, L_BUF_SIZE, "%slow.%d.c", filename, fileindex);
     else
         sprintf(bigbuf, "%slow.%d.c", OUTROOT, fileindex);
     l_binaryWrite(bigbuf, "w", filestr, nbytes);

--- a/src/fmorphauto.c
+++ b/src/fmorphauto.c
@@ -457,7 +457,7 @@ SARRAY  *sa1, *sa2, *sa3;
         return ERROR_INT("filestr from sa3 not made", procName, 1);
     nbytes = strlen(filestr);
     if (filename)
-        sprintf(bigbuf, "%s.%d.c", filename, fileindex);
+        snprintf(bigbuf, L_BUF_SIZE, "%s.%d.c", filename, fileindex);
     else
         sprintf(bigbuf, "%s.%d.c", OUTROOT, fileindex);
     l_binaryWrite(bigbuf, "w", filestr, nbytes);
@@ -644,7 +644,7 @@ SEL     *sel;
         return ERROR_INT("filestr from sa4 not made", procName, 1);
     nbytes = strlen(filestr);
     if (filename)
-        sprintf(bigbuf, "%slow.%d.c", filename, fileindex);
+        snprintf(bigbuf, L_BUF_SIZE, "%slow.%d.c", filename, fileindex);
     else
         sprintf(bigbuf, "%slow.%d.c", OUTROOT, fileindex);
     l_binaryWrite(bigbuf, "w", filestr, nbytes);


### PR DESCRIPTION
Coverity scan reports:

CID 1365273 (#1 of 1): Unbounded source buffer (STRING_SIZE)
CID 1365364 ...
CID 1365429 ...

This fix only avoids the buffer overrun.
Supporting any length of filename would require more changes.

Signed-off-by: Stefan Weil <sw@weilnetz.de>