### PR TITLE
binarize: Fix use of unitialized value

### DIFF
--- a/src/binarize.c
+++ b/src/binarize.c
@@ -659,8 +659,6 @@ PIX     *pixg, *pixsc, *pixm, *pixms, *pixth, *pixd;
         pixDestroy(&pixth);
     if (ppixd)
         *ppixd = pixd;
-    else
-        pixDestroy(&pixd);
     pixDestroy(&pixg);
     pixDestroy(&pixsc);
     return 0;


### PR DESCRIPTION
Coverity scan report:

CID 1365363: Uninitialized pointer read

pixd is only assigned a value if ppixd != NULL.

Signed-off-by: Stefan Weil <sw@weilnetz.de>