### PR TITLE
autobuild: Use glibtoolize if libtoolize is unavailable

### DIFF
--- a/autobuild
+++ b/autobuild
@@ -2,7 +2,7 @@
 #
 #  autobuild
 
-libtoolize -c -f
+libtoolize -c -f || glibtoolize -c -f
 aclocal
 autoheader -f
 autoconf


### PR DESCRIPTION
This is needed for builds with MacPorts and other platforms which
do not have libtoolize.

Signed-off-by: Stefan Weil <sw@weilnetz.de>