### PR TITLE
travis: Activate CI for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: trusty
 
 os:
   - linux
-  #- osx
+  - osx
 
 branches:
   only:
@@ -33,8 +33,8 @@ before_install:
 install:
   - if [[ $LINUX ]]; then sudo apt-get update; fi
   - if [[ $LINUX ]]; then sudo apt-get install -y libwebp-dev libpng12-dev libjpeg8-dev libtiff5-dev libgif-dev libopenjpeg-dev; fi
-  - wget https://www.cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh
-  - sudo sh cmake-3.6.1-Linux-x86_64.sh --skip-license --prefix=/usr
+  - if [[ $LINUX ]]; then wget https://www.cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh; fi
+  - if [[ $LINUX ]]; then sudo sh cmake-3.6.1-Linux-x86_64.sh --skip-license --prefix=/usr; fi
 
 script:
   - mkdir build


### PR DESCRIPTION
Don't use cmake-3.6.1-Linux-x86_64.sh when testing on macOS.

Signed-off-by: Stefan Weil <sw@weilnetz.de>