### PR TITLE
Disable libtiff warnings for best performance.

### DIFF
--- a/src/tiffio.c
+++ b/src/tiffio.c
@@ -1132,6 +1132,11 @@ l_uint32   uval, uval2;
     return 0;
 }
 
+void 
+dummyHandler(const char* module, const char* fmt, va_list ap)
+{
+	// ignore errors and warnings (or handle them your own way)
+}
 
 /*--------------------------------------------------------------*
  *               Reading and writing multipage tiff             *
@@ -1182,6 +1187,9 @@ TIFF    *tif;
         return (PIX *)ERROR_PTR("fname not defined", procName, NULL);
     if (!poffset)
         return (PIX *)ERROR_PTR("&offset not defined", procName, NULL);
+
+	// disable warnings
+	TIFFSetWarningHandler(dummyHandler);
 
     if ((tif = TIFFOpen(fname, "r")) == NULL) {
         L_ERROR("tif open failed for %s\n", procName, fname);
@@ -2070,6 +2078,9 @@ fopenTiff(FILE        *fp,
     if (!modestring)
         return (TIFF *)ERROR_PTR("modestring not defined", procName, NULL);
 
+	// disable warnings
+	TIFFSetWarningHandler(dummyHandler);
+
     fseek(fp, 0, SEEK_SET);
     return TIFFClientOpen("TIFFstream", modestring, (thandle_t)fp,
                           lept_read_proc, lept_write_proc, lept_seek_proc,
@@ -2105,6 +2116,9 @@ TIFF  *tif;
         return (TIFF *)ERROR_PTR("filename not defined", procName, NULL);
     if (!modestring)
         return (TIFF *)ERROR_PTR("modestring not defined", procName, NULL);
+
+	// disable warnings
+	TIFFSetWarningHandler(dummyHandler);
 
     fname = genPathname(filename, NULL);
     tif = TIFFOpen(fname, modestring);
@@ -2383,6 +2397,9 @@ L_MEMSTREAM  *mstream;
     else
         mstream = memstreamCreateForWrite(pdata, pdatasize);
 
+	// disable warnings
+	TIFFSetWarningHandler(dummyHandler);
+
     return TIFFClientOpen(filename, operation, (thandle_t)mstream,
                           tiffReadCallback, tiffWriteCallback,
                           tiffSeekCallback, tiffCloseCallback,
@@ -2567,9 +2584,6 @@ PIXA   *pixa;
  * Notes:
  *      (1) fopenTiffMemstream() does not work in append mode, so we
  *          must work-around with a temporary file.
- *      (2) Getting a file stream from
- *            open_memstream((char **)pdata, psize)
- *          does not work with the tiff directory.
  * </pre>
  */
 l_int32

--- a/src/tiffio.c
+++ b/src/tiffio.c
@@ -2584,6 +2584,9 @@ PIXA   *pixa;
  * Notes:
  *      (1) fopenTiffMemstream() does not work in append mode, so we
  *          must work-around with a temporary file.
+ *      (2) Getting a file stream from
+ *            open_memstream((char **)pdata, psize)
+ *          does not work with the tiff directory.
  * </pre>
  */
 l_int32


### PR DESCRIPTION
libtiff tends to complain a great deal unnecessarily.  For example, TIFF allows vendor-defined tags but libtiff complains about them  The proposed change silences warnings for best performance.  libtiff errors are allowed to be reported.