### PR TITLE
Fix cmake Release optimization level

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ if (MSVC)
     set_source_files_properties(${src} PROPERTIES LANGUAGE CXX)
 endif()
 
+string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE})
+
 add_library                     (leptonica ${LIBRARY_TYPE} ${src} ${hdr})
 set_target_properties           (leptonica PROPERTIES VERSION   ${VERSION_PLAIN})
 set_target_properties           (leptonica PROPERTIES SOVERSION 5.1.0)


### PR DESCRIPTION
Similar to [tesseract#1100](https://github.com/tesseract-ocr/tesseract/pull/1100), the cmake file installs an incorrectly named library. Changes `libleptonica` to `liblept`.