### PR TITLE
add support for openjpeg 2.3

### DIFF
--- a/cmake/Configure.cmake
+++ b/cmake/Configure.cmake
@@ -67,6 +67,7 @@ set(include_files_list
     openjpeg-2.0/openjpeg.h
     openjpeg-2.1/openjpeg.h
     openjpeg-2.2/openjpeg.h
+    openjpeg-2.3/openjpeg.h
 )
 check_includes(include_files_list)
 
@@ -149,6 +150,10 @@ file(APPEND ${AUTOCONFIG_SRC} "
 
 #ifdef HAVE_OPENJPEG_2_2_OPENJPEG_H
 #define LIBJP2K_HEADER <openjpeg-2.2/openjpeg.h>
+#endif
+
+#ifdef HAVE_OPENJPEG_2_3_OPENJPEG_H
+#define LIBJP2K_HEADER <openjpeg-2.3/openjpeg.h>
 #endif
 ")
 


### PR DESCRIPTION
Small changes to add support for openjpeg 2.3.
This is in particular necessary to compile on msys2.