### PR TITLE
README.md: Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ www.leptonica.org
 ## Open Source Projects that use Leptonica ##
   * [tesseract](https://github.com/tesseract-ocr/tesseract/) (optical character recognition)
   * [OpenCV](https://github.com/opencv/opencv) (computer vision library)
-  * [jbig2enc](http://www.imperialviolet.org/jbig2.html) (encodes multipage binary image documents with jbig2 compression)
+  * [jbig2enc](https://github.com/agl/jbig2enc) (encodes multipage binary image documents with jbig2 compression)
   * [php](http://en.wikipedia.org/wiki/PHP)  (scripting language for dynamic web pages)
 
 ## Major contributors to Leptonica ##


### PR DESCRIPTION
jbig2enc: The (previous) link redirects to another url, so use that url directly.