### PR TITLE
Check for $() in gplotCreate()

### DIFF
--- a/src/gplot.c
+++ b/src/gplot.c
@@ -153,7 +153,7 @@ GPLOT   *gplot;
     if (outformat != GPLOT_PNG && outformat != GPLOT_PS &&
         outformat != GPLOT_EPS && outformat != GPLOT_LATEX)
         return (GPLOT *)ERROR_PTR("outformat invalid", procName, NULL);
-    stringCheckForChars(rootname, "`;&|><\"?*", &badchar);
+    stringCheckForChars(rootname, "`;&|><\"?*$()", &badchar);
     if (badchar)  /* danger of command injection */
         return (GPLOT *)ERROR_PTR("invalid rootname", procName, NULL);
 


### PR DESCRIPTION
This adds $() to the list of bad characters to look for in src/gplot.c to
prevent `$(command)` from being executed as reported in #303.

However, this should not be considered a real fix, since it violates rule 2 of
the [Six Dumbest Ideas in Computer Security][1], namely "Enumerating badness".

[1]: http://www.ranum.com/security/computer_security/editorials/dumb/