### PR TITLE
Fix some compiler warnings for MS C

### DIFF
--- a/src/pix.h
+++ b/src/pix.h
@@ -240,9 +240,9 @@ enum {
  *          International Telecommunications Union, via ITU-R.
  * </pre>
  */
-static const l_float32  L_RED_WEIGHT =   0.3;  /*!< Percept. weight for red   */
-static const l_float32  L_GREEN_WEIGHT = 0.5;  /*!< Percept. weight for green */
-static const l_float32  L_BLUE_WEIGHT =  0.2;  /*!< Percept. weight for blue  */
+static const l_float32 L_RED_WEIGHT =   0.3f; /*!< Percept. weight for red   */
+static const l_float32 L_GREEN_WEIGHT = 0.5f; /*!< Percept. weight for green */
+static const l_float32 L_BLUE_WEIGHT =  0.2f; /*!< Percept. weight for blue  */
 
 
 /*-------------------------------------------------------------------------*


### PR DESCRIPTION
The MS compiler complains each time when pix.h is included.
When building tesseract, this contributes more than 300 warnings:

src\pix.h(243): warning C4305: 'initializing':
 truncation from 'double' to 'l_float32' (compiling source file ...
src\pix.h(245): warning C4305: 'initializing':
 truncation from 'double' to 'l_float32' (compiling source file ...

The compiler does not complain for line 244, maybe because
a 32 bit float can store 0.5 without any truncation.

Using float constant values should fix those warnings.

Signed-off-by: Stefan Weil <sw@weilnetz.de>