### PR TITLE
Fix MS C compiler warnings

### DIFF
--- a/prog/compfilter_reg.c
+++ b/prog/compfilter_reg.c
@@ -38,8 +38,8 @@ static void Count_pieces2(L_REGPARAMS *rp, BOXA *boxa, l_int32 nexp);
 static l_int32 Count_ones(L_REGPARAMS *rp, NUMA  *na, l_int32 nexp,
                           l_int32 index, const char *name);
 
-static const l_float32 edges[13] = {0.0, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5,
-                                    0.55, 0.6, 0.7, 0.8, 0.9, 1.0};
+static const l_float32 edges[13] = {0.0f, 0.2f, 0.3f, 0.35f, 0.4f, 0.45f, 0.5f,
+                                    0.55f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f};
 
     /* for feyn.tif */
 static const l_int32 band[12] = {1, 11, 48, 264, 574, 704, 908, 786, 466,

--- a/prog/contrasttest.c
+++ b/prog/contrasttest.c
@@ -41,7 +41,7 @@ char        *filein, *fileout;
 char         bigbuf[512];
 l_int32      iplot;
 l_float32    factor;    /* scaled width of atan curve */
-l_float32    fact[] = {.2, 0.4, 0.6, 0.8, 1.0, -1.0};
+l_float32    fact[] = {0.2f, 0.4f, 0.6f, 0.8f, 1.0f, -1.0f};
 GPLOT       *gplot;
 NUMA        *na, *nax;
 PIX         *pixs;

--- a/prog/otsutest1.c
+++ b/prog/otsutest1.c
@@ -36,7 +36,7 @@ static const l_int32 gaussmean1[5] = {20, 40, 60, 80, 60};
 static const l_int32 gaussstdev1[5] = {10, 20, 20, 20, 30};
 static const l_int32 gaussmean2[5] = {220, 200, 140, 180, 150};
 static const l_int32 gaussstdev2[5] = {15, 20, 40, 20, 30};
-static const l_float32 gaussfract1[5] = {0.2, 0.3, 0.1, 0.5, 0.3};
+static const l_float32 gaussfract1[5] = {0.2f, 0.3f, 0.1f, 0.5f, 0.3f};
 static char  buf[256];
 
 static l_int32  GenerateSplitPlot(l_int32 i);

--- a/prog/recogtest1.c
+++ b/prog/recogtest1.c
@@ -126,7 +126,7 @@ SARRAY    *sa, *satext;
          *             requiring retention of 20% of templates in each class
          *  0.9, 0.01 : remove most based on matching; saved 1 in each class */
     fprintf(stderr, "Remove outliers\n");
-    static const l_float32  MinScore[] = {0.6, 0.7, 0.9};
+    static const l_float32  MinScore[] = {0.6f, 0.7f, 0.9f};
     static const l_int32  MinTarget[] = {4, 5, 4};
     static const l_int32  MinSize[] = {3, 2, 3};
     pixa2 = recogExtractPixa(recog1);

--- a/prog/scale_reg.c
+++ b/prog/scale_reg.c
@@ -47,7 +47,7 @@ static const char *image[10] = {"feyn.tif",         /* 1 bpp */
 
 static const l_int32    SPACE = 30;
 static const l_int32    WIDTH = 300;
-static const l_float32  FACTOR[5] = {2.3, 1.5, 1.1, 0.6, 0.3};
+static const l_float32  FACTOR[5] = {2.3f, 1.5f, 1.1f, 0.6f, 0.3f};
 
 static void AddScaledImages(PIXA *pixa, const char *fname, l_int32 width);
 static void PixSave32(PIXA *pixa, PIX *pixc);

--- a/prog/warper_reg.c
+++ b/prog/warper_reg.c
@@ -36,10 +36,10 @@ static void DisplayCaptcha(PIXA *pixac, PIX *pixs, l_int32 nterms,
                            l_uint32 seed, l_int32 newline);
 
 static const l_int32 size = 4;
-static const l_float32 xmag[] = {3.0, 4.0, 5.0, 7.0};
-static const l_float32 ymag[] = {5.0, 6.0, 8.0, 10.0};
-static const l_float32 xfreq[] = {0.11, 0.10, 0.10, 0.12};
-static const l_float32 yfreq[] = {0.11, 0.13, 0.13, 0.15};
+static const l_float32 xmag[] = {3.0f, 4.0f, 5.0f, 7.0f};
+static const l_float32 ymag[] = {5.0f, 6.0f, 8.0f, 10.0f};
+static const l_float32 xfreq[] = {0.11f, 0.10f, 0.10f, 0.12f};
+static const l_float32 yfreq[] = {0.11f, 0.13f, 0.13f, 0.15f};
 static const l_int32 nx[] = {4, 3, 2, 1};
 static const l_int32 ny[] = {4, 3, 2, 1};
 


### PR DESCRIPTION
This fixes most warnings in the Appveyor CI builds:

C:\projects\leptonica\prog\compfilter_reg.c(42): warning C4838:
 conversion from 'double' to 'const l_float32' requires a narrowing conversion

C:\projects\leptonica\prog\contrasttest.c(44): warning C4838:
 conversion from 'double' to 'l_float32' requires a narrowing conversion

C:\projects\leptonica\prog\otsutest1.c(39): warning C4838:
 conversion from 'double' to 'const l_float32' requires a narrowing conversion

C:\projects\leptonica\prog\recogtest1.c(129): warning C4838:
 conversion from 'double' to 'const l_float32' requires a narrowing conversion

[C:\projects\leptonica\prog\scale_reg.c(50): warning C4838:
 conversion from 'double' to 'const l_float32' requires a narrowing conversion

C:\projects\leptonica\prog\warper_reg.c(41): warning C4838:
 conversion from 'double' to 'const l_float32' requires a narrowing conversion
C:\projects\leptonica\prog\warper_reg.c(42): warning C4838:
 conversion from 'double' to 'const l_float32' requires a narrowing conversion

Signed-off-by: Stefan Weil <sw@weilnetz.de>