### PR TITLE
fix broken include paths on msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,8 @@ include(Configure)
 
 configure_file(${AUTOCONFIG_SRC} ${AUTOCONFIG} @ONLY)
 
-set(INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include" "${CMAKE_INSTALL_PREFIX}/include/leptonica")
+set(INCLUDE_DIR_INC "${CMAKE_INSTALL_PREFIX}/include")
+set(INCLUDE_DIR_INCLEPT "${CMAKE_INSTALL_PREFIX}/include/leptonica")
 
 configure_file(
     ${CMAKE_SOURCE_DIR}/cmake/templates/LeptonicaConfig-version.cmake.in

--- a/cmake/templates/LeptonicaConfig.cmake.in
+++ b/cmake/templates/LeptonicaConfig.cmake.in
@@ -36,7 +36,7 @@ SET(Leptonica_VERSION_PATCH     @VERSION_PATCH@)
 # ======================================================
 
 # Provide the include directories to the caller
-set(Leptonica_INCLUDE_DIRS @INCLUDE_DIR@)
+set(Leptonica_INCLUDE_DIRS "@INCLUDE_DIR_INC@" "@INCLUDE_DIR_INCLEPT@")
 
 # ====================================================================
 # Link libraries:


### PR DESCRIPTION
LeptonicaConfig.cmake include directories are formatted wrongly

The current cmake files result in semicolon separated paths:
`set(Leptonica_INCLUDE_DIRS C:/ProgramFiles/leptonica/include;C:/ProgramFiles/leptonica/include/leptonica)`
I am unsure where the problem is exactly here, but as you can see the spaces of "Program Files" had been removed, and the paths are not quoted correctly. This PR produces now include paths formatted as below.

`set(Leptonica_INCLUDE_DIRS "C:/Program Files/leptonica/include" "C:/Program Files/leptonica/include/leptonica")`

i was building with Visual Studio 2015 and CMake 3.11