### PR TITLE
autobuild: Add check for missing pkg-config

### DIFF
--- a/autobuild
+++ b/autobuild
@@ -6,5 +6,10 @@ libtoolize -c -f || glibtoolize -c -f
 aclocal
 autoheader -f
 autoconf
+if grep -q PKG_CHECK_MODULES configure; then
+  # The generated configure is invalid because pkg-config is unavailable.
+  rm configure
+  echo "Error, missing pkg-config. Check the build requirements."
+  exit 1
+fi
 automake -a -c -f
-


### PR DESCRIPTION
Tell users if pkg-config is missing instead of generating an invalid
configure script which fails with strange error messages.

Signed-off-by: Stefan Weil <sw@weilnetz.de>