### PR TITLE
Fix Doxygen warnings.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.11
+# Doxyfile 1.8.14
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -20,8 +20,8 @@
 # This tag specifies the encoding used for all characters in the config file
 # that follow. The default is UTF-8 which is also the encoding used for all text
 # before the first occurrence of this tag. Doxygen uses libiconv (or the iconv
-# built into libc) for the transcoding. See http://www.gnu.org/software/libiconv
-# for the list of possible encodings.
+# built into libc) for the transcoding. See
+# https://www.gnu.org/software/libiconv/ for the list of possible encodings.
 # The default value is: UTF-8.
 
 DOXYFILE_ENCODING      = UTF-8
@@ -32,13 +32,13 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Leptonica"
+PROJECT_NAME           = Leptonica
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.73
+PROJECT_NUMBER         = 1.76.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -118,7 +118,7 @@ REPEAT_BRIEF           = YES
 # the entity):The $name class, The $name widget, The $name file, is, provides,
 # specifies, contains, represents, a, an and the.
 
-ABBREVIATE_BRIEF       =
+ABBREVIATE_BRIEF       = 
 
 # If the ALWAYS_DETAILED_SEC and REPEAT_BRIEF tags are both set to YES then
 # doxygen will generate a detailed section even if there is only a brief
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = 
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = 
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -226,15 +226,16 @@ TAB_SIZE               = 4
 # will allow you to put the command \sideeffect (or @sideeffect) in the
 # documentation, which will result in a user-defined paragraph with heading
 # "Side Effects:". You can put \n's in the value part of an alias to insert
-# newlines.
+# newlines (in the resulting output). You can put ^^ in the value part of an
+# alias to insert a newline as if a physical newline was in the original file.
 
-ALIASES                =
+ALIASES                = 
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              =
+TCL_SUBST              = 
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -293,6 +294,15 @@ EXTENSION_MAPPING      = inc=C
 
 MARKDOWN_SUPPORT       = YES
 
+# When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
+# to that level are automatically included in the table of contents, even if
+# they do not have an id attribute.
+# Note: This feature currently applies only to Markdown headings.
+# Minimum value: 0, maximum value: 99, default value: 0.
+# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
+
+TOC_INCLUDE_HEADINGS   = 0
+
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can
 # be prevented in individual cases by putting a % sign in front of the word or
@@ -318,7 +328,7 @@ BUILTIN_STL_SUPPORT    = NO
 CPP_CLI_SUPPORT        = NO
 
 # Set the SIP_SUPPORT tag to YES if your project consists of sip (see:
-# http://www.riverbankcomputing.co.uk/software/sip/intro) sources only. Doxygen
+# https://www.riverbankcomputing.com/software/sip/intro) sources only. Doxygen
 # will parse them like normal C++ but will assume all classes use public instead
 # of private inheritance when no explicit protection keyword is present.
 # The default value is: NO.
@@ -629,7 +639,7 @@ GENERATE_DEPRECATEDLIST= YES
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
 
-ENABLED_SECTIONS       =
+ENABLED_SECTIONS       = 
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines that the
 # initial value of a variable or macro / define can have for it to appear in the
@@ -671,7 +681,7 @@ SHOW_NAMESPACES        = YES
 # by doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.
 
-FILE_VERSION_FILTER    =
+FILE_VERSION_FILTER    = 
 
 # The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
 # by doxygen. The layout file controls the global structure of the generated
@@ -684,17 +694,17 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            =
+LAYOUT_FILE            = 
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
 # extension is automatically appended if omitted. This requires the bibtex tool
-# to be installed. See also http://en.wikipedia.org/wiki/BibTeX for more info.
+# to be installed. See also https://en.wikipedia.org/wiki/BibTeX for more info.
 # For LaTeX the style of the bibliography can be controlled using
 # LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
 # search path. See also \cite for info how to create references.
 
-CITE_BIB_FILES         =
+CITE_BIB_FILES         = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -776,7 +786,7 @@ INPUT                  = src
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv
-# documentation (see: http://www.gnu.org/software/libiconv) for the list of
+# documentation (see: https://www.gnu.org/software/libiconv/) for the list of
 # possible encodings.
 # The default value is: UTF-8.
 
@@ -793,10 +803,12 @@ INPUT_ENCODING         = UTF-8
 # If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
 # *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
 # *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc,
-# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f, *.for, *.tcl,
-# *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
+# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
+# *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.c *.h mainpage.txt
+FILE_PATTERNS          = *.c \
+                         *.h \
+                         mainpage.txt
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -811,7 +823,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = 
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -827,7 +839,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -838,7 +850,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = 
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -851,7 +863,8 @@ EXAMPLE_PATH           = prog
 # *.h) to filter out the source-files in the directories. If left blank all
 # files are included.
 
-EXAMPLE_PATTERNS       = *.c *.h
+EXAMPLE_PATTERNS       = *.c \
+                         *.h
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands
@@ -885,7 +898,7 @@ IMAGE_PATH             = prog
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           =
+INPUT_FILTER           = 
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the
@@ -898,7 +911,7 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-FILTER_PATTERNS        =
+FILTER_PATTERNS        = 
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for
@@ -913,14 +926,14 @@ FILTER_SOURCE_FILES    = NO
 # *.ext= (so without naming a filter).
 # This tag requires that the tag FILTER_SOURCE_FILES is set to YES.
 
-FILTER_SOURCE_PATTERNS =
+FILTER_SOURCE_PATTERNS = 
 
 # If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
 # is part of the input, its contents will be placed on the main page
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -981,7 +994,7 @@ SOURCE_TOOLTIPS        = YES
 # If the USE_HTAGS tag is set to YES then the references to source code will
 # point to the HTML generated by the htags(1) tool instead of doxygen built-in
 # source browser. The htags tool is part of GNU's global source tagging system
-# (see http://www.gnu.org/software/global/global.html). You will need version
+# (see https://www.gnu.org/software/global/global.html). You will need version
 # 4.8.6 or higher.
 #
 # To use it do the following:
@@ -1032,7 +1045,7 @@ COLS_IN_ALPHA_INDEX    = 5
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          =
+IGNORE_PREFIX          = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -1076,7 +1089,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            =
+HTML_HEADER            = 
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1086,7 +1099,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            =
+HTML_FOOTER            = 
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1098,7 +1111,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        =
+HTML_STYLESHEET        = 
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1111,7 +1124,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = 
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note
@@ -1126,7 +1139,7 @@ HTML_EXTRA_FILES       = moller52.jpg
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
 # this color. Hue is specified as an angle on a colorwheel, see
-# http://en.wikipedia.org/wiki/Hue for more information. For instance the value
+# https://en.wikipedia.org/wiki/Hue for more information. For instance the value
 # 0 represents red, 60 is yellow, 120 is green, 180 is cyan, 240 is blue, 300
 # purple, and 360 is red again.
 # Minimum value: 0, maximum value: 359, default value: 220.
@@ -1162,6 +1175,17 @@ HTML_COLORSTYLE_GAMMA  = 80
 
 HTML_TIMESTAMP         = NO
 
+# If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
+# documentation will contain a main index with vertical navigation menus that
+# are dynamically created via Javascript. If disabled, the navigation index will
+# consists of multiple levels of tabs that are statically embedded in every HTML
+# page. Disable this option to support browsers that do not have Javascript,
+# like the Qt help browser.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_DYNAMIC_MENUS     = YES
+
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded.
@@ -1185,12 +1209,12 @@ HTML_INDEX_NUM_ENTRIES = 100
 
 # If the GENERATE_DOCSET tag is set to YES, additional index files will be
 # generated that can be used as input for Apple's Xcode 3 integrated development
-# environment (see: http://developer.apple.com/tools/xcode/), introduced with
+# environment (see: https://developer.apple.com/tools/xcode/), introduced with
 # OSX 10.5 (Leopard). To create a documentation set, doxygen will generate a
 # Makefile in the HTML output directory. Running make will produce the docset in
 # that directory and running make install will install the docset in
 # ~/Library/Developer/Shared/Documentation/DocSets so that Xcode will find it at
-# startup. See http://developer.apple.com/tools/creatingdocsetswithdoxygen.html
+# startup. See https://developer.apple.com/tools/creatingdocsetswithdoxygen.html
 # for more information.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
@@ -1250,7 +1274,7 @@ GENERATE_HTMLHELP      = NO
 # written to the html output directory.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_FILE               =
+CHM_FILE               = 
 
 # The HHC_LOCATION tag can be used to specify the location (absolute path
 # including file name) of the HTML help compiler (hhc.exe). If non-empty,
@@ -1258,7 +1282,7 @@ CHM_FILE               =
 # The file has to be specified with full path.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-HHC_LOCATION           =
+HHC_LOCATION           = 
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
 # (YES) or that it should be included in the master .chm file (NO).
@@ -1271,7 +1295,7 @@ GENERATE_CHI           = NO
 # and project file content.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_INDEX_ENCODING     =
+CHM_INDEX_ENCODING     = 
 
 # The BINARY_TOC flag controls whether a binary table of contents is generated
 # (YES) or a normal table of contents (NO) in the .chm file. Furthermore it
@@ -1302,11 +1326,11 @@ GENERATE_QHP           = NO
 # the HTML output folder.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QCH_FILE               =
+QCH_FILE               = 
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
-# (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#namespace).
+# (see: http://doc.qt.io/qt-4.8/qthelpproject.html#namespace).
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1314,8 +1338,7 @@ QHP_NAMESPACE          = org.doxygen.Project
 
 # The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating Qt
 # Help Project output. For more information please see Qt Help Project / Virtual
-# Folders (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#virtual-
-# folders).
+# Folders (see: http://doc.qt.io/qt-4.8/qthelpproject.html#virtual-folders).
 # The default value is: doc.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1323,33 +1346,31 @@ QHP_VIRTUAL_FOLDER     = doc
 
 # If the QHP_CUST_FILTER_NAME tag is set, it specifies the name of a custom
 # filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#custom-
-# filters).
+# Filters (see: http://doc.qt.io/qt-4.8/qthelpproject.html#custom-filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_NAME   = 
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#custom-
-# filters).
+# Filters (see: http://doc.qt.io/qt-4.8/qthelpproject.html#custom-filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_ATTRS  =
+QHP_CUST_FILTER_ATTRS  = 
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
-# http://qt-project.org/doc/qt-4.8/qthelpproject.html#filter-attributes).
+# http://doc.qt.io/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_SECT_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  = 
 
 # The QHG_LOCATION tag can be used to specify the location of Qt's
 # qhelpgenerator. If non-empty doxygen will try to run qhelpgenerator on the
 # generated .qhp file.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHG_LOCATION           =
+QHG_LOCATION           = 
 
 # If the GENERATE_ECLIPSEHELP tag is set to YES, additional index files will be
 # generated, together with the HTML files, they form an Eclipse help plugin. To
@@ -1397,7 +1418,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.
@@ -1432,7 +1453,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #
@@ -1444,7 +1465,7 @@ FORMULA_FONTSIZE       = 10
 FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
-# http://www.mathjax.org) which uses client side Javascript for the rendering
+# https://www.mathjax.org) which uses client side Javascript for the rendering
 # instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
 # installed or if you want to formulas look prettier in the HTML output. When
 # enabled you may also need to install MathJax separately and configure the path
@@ -1471,8 +1492,8 @@ MATHJAX_FORMAT         = HTML-CSS
 # MATHJAX_RELPATH should be ../mathjax. The default value points to the MathJax
 # Content Delivery Network so you can quickly see the result without installing
 # MathJax. However, it is strongly recommended to install a local copy of
-# MathJax from http://www.mathjax.org before deployment.
-# The default value is: http://cdn.mathjax.org/mathjax/latest.
+# MathJax from https://www.mathjax.org before deployment.
+# The default value is: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
@@ -1482,7 +1503,7 @@ MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_EXTENSIONS     =
+MATHJAX_EXTENSIONS     = 
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site
@@ -1490,7 +1511,7 @@ MATHJAX_EXTENSIONS     =
 # example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_CODEFILE       =
+MATHJAX_CODEFILE       = 
 
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box for
 # the HTML output. The underlying search engine uses javascript and DHTML and
@@ -1533,7 +1554,7 @@ SERVER_BASED_SEARCH    = NO
 #
 # Doxygen ships with an example indexer (doxyindexer) and search engine
 # (doxysearch.cgi) which are based on the open source search engine library
-# Xapian (see: http://xapian.org/).
+# Xapian (see: https://xapian.org/).
 #
 # See the section "External Indexing and Searching" for details.
 # The default value is: NO.
@@ -1546,11 +1567,11 @@ EXTERNAL_SEARCH        = NO
 #
 # Doxygen ships with an example indexer (doxyindexer) and search engine
 # (doxysearch.cgi) which are based on the open source search engine library
-# Xapian (see: http://xapian.org/). See the section "External Indexing and
+# Xapian (see: https://xapian.org/). See the section "External Indexing and
 # Searching" for details.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-SEARCHENGINE_URL       =
+SEARCHENGINE_URL       = 
 
 # When SERVER_BASED_SEARCH and EXTERNAL_SEARCH are both enabled the unindexed
 # search data is written to a file for indexing by an external tool. With the
@@ -1566,7 +1587,7 @@ SEARCHDATA_FILE        = searchdata.xml
 # projects and redirect the results back to the right project.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTERNAL_SEARCH_ID     =
+EXTERNAL_SEARCH_ID     = 
 
 # The EXTRA_SEARCH_MAPPINGS tag can be used to enable searching through doxygen
 # projects other than the one defined by this configuration file, but that are
@@ -1576,7 +1597,7 @@ EXTERNAL_SEARCH_ID     =
 # EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTRA_SEARCH_MAPPINGS  =
+EXTRA_SEARCH_MAPPINGS  = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output
@@ -1640,7 +1661,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = 
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -1656,7 +1677,7 @@ EXTRA_PACKAGES         =
 # to HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_HEADER           =
+LATEX_HEADER           = 
 
 # The LATEX_FOOTER tag can be used to specify a personal LaTeX footer for the
 # generated LaTeX document. The footer should contain everything after the last
@@ -1667,7 +1688,7 @@ LATEX_HEADER           =
 # Note: Only use a user-defined footer if you know what you are doing!
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_FOOTER           =
+LATEX_FOOTER           = 
 
 # The LATEX_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # LaTeX style sheets that are included after the standard style sheets created
@@ -1678,7 +1699,7 @@ LATEX_FOOTER           =
 # list).
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_STYLESHEET = 
 
 # The LATEX_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the LATEX_OUTPUT output
@@ -1686,7 +1707,7 @@ LATEX_EXTRA_STYLESHEET =
 # markers available.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_FILES      =
+LATEX_EXTRA_FILES      = 
 
 # If the PDF_HYPERLINKS tag is set to YES, the LaTeX that is generated is
 # prepared for conversion to PDF (using ps2pdf or pdflatex). The PDF file will
@@ -1733,7 +1754,7 @@ LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
-# http://en.wikipedia.org/wiki/BibTeX and \cite for more info.
+# https://en.wikipedia.org/wiki/BibTeX and \cite for more info.
 # The default value is: plain.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
@@ -1794,14 +1815,14 @@ RTF_HYPERLINKS         = NO
 # default style sheet that doxygen normally uses.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_STYLESHEET_FILE    =
+RTF_STYLESHEET_FILE    = 
 
 # Set optional variables used in the generation of an RTF document. Syntax is
 # similar to doxygen's config file. A template extensions file can be generated
 # using doxygen -e rtf extensionFile.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_EXTENSIONS_FILE    =
+RTF_EXTENSIONS_FILE    = 
 
 # If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
 # with syntax highlighting in the RTF output.
@@ -1846,7 +1867,7 @@ MAN_EXTENSION          = .3
 # MAN_EXTENSION with the initial . removed.
 # This tag requires that the tag GENERATE_MAN is set to YES.
 
-MAN_SUBDIR             =
+MAN_SUBDIR             = 
 
 # If the MAN_LINKS tag is set to YES and doxygen generates man output, then it
 # will generate one additional man file for each entity documented in the real
@@ -1916,9 +1937,9 @@ DOCBOOK_PROGRAMLISTING = NO
 #---------------------------------------------------------------------------
 
 # If the GENERATE_AUTOGEN_DEF tag is set to YES, doxygen will generate an
-# AutoGen Definitions (see http://autogen.sf.net) file that captures the
-# structure of the code including all documentation. Note that this feature is
-# still experimental and incomplete at the moment.
+# AutoGen Definitions (see http://autogen.sourceforge.net/) file that captures
+# the structure of the code including all documentation. Note that this feature
+# is still experimental and incomplete at the moment.
 # The default value is: NO.
 
 GENERATE_AUTOGEN_DEF   = NO
@@ -1959,7 +1980,7 @@ PERLMOD_PRETTY         = YES
 # overwrite each other's variables.
 # This tag requires that the tag GENERATE_PERLMOD is set to YES.
 
-PERLMOD_MAKEVAR_PREFIX =
+PERLMOD_MAKEVAR_PREFIX = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
@@ -2000,7 +2021,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           =
+INCLUDE_PATH           = 
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2008,7 +2029,7 @@ INCLUDE_PATH           =
 # used.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-INCLUDE_FILE_PATTERNS  =
+INCLUDE_FILE_PATTERNS  = 
 
 # The PREDEFINED tag can be used to specify one or more macro names that are
 # defined before the preprocessor is started (similar to the -D option of e.g.
@@ -2018,7 +2039,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2027,7 +2048,7 @@ PREDEFINED             =
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = 
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2056,13 +2077,13 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = 
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = 
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be
@@ -2111,14 +2132,14 @@ CLASS_DIAGRAMS         = YES
 # the mscgen tool resides. If left empty the tool is assumed to be found in the
 # default search path.
 
-MSCGEN_PATH            =
+MSCGEN_PATH            = 
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
 # If left empty dia is assumed to be found in the default search path.
 
-DIA_PATH               =
+DIA_PATH               = 
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
@@ -2167,7 +2188,7 @@ DOT_FONTSIZE           = 10
 # the path where dot can find it using this tag.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTPATH           =
+DOT_FONTPATH           = 
 
 # If the CLASS_GRAPH tag is set to YES then doxygen will generate a graph for
 # each documented class showing the direct and indirect inheritance relations.
@@ -2311,26 +2332,26 @@ INTERACTIVE_SVG        = NO
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               =
+DOT_PATH               = 
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile
 # command).
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOTFILE_DIRS           =
+DOTFILE_DIRS           = 
 
 # The MSCFILE_DIRS tag can be used to specify one or more directories that
 # contain msc files that are included in the documentation (see the \mscfile
 # command).
 
-MSCFILE_DIRS           =
+MSCFILE_DIRS           = 
 
 # The DIAFILE_DIRS tag can be used to specify one or more directories that
 # contain dia files that are included in the documentation (see the \diafile
 # command).
 
-DIAFILE_DIRS           =
+DIAFILE_DIRS           = 
 
 # When using plantuml, the PLANTUML_JAR_PATH tag should be used to specify the
 # path where java can find the plantuml.jar file. If left blank, it is assumed
@@ -2338,12 +2359,17 @@ DIAFILE_DIRS           =
 # generate a warning when it encounters a \startuml command in this case and
 # will not generate output for the diagram.
 
-PLANTUML_JAR_PATH      =
+PLANTUML_JAR_PATH      = 
+
+# When using plantuml, the PLANTUML_CFG_FILE tag can be used to specify a
+# configuration file for plantuml.
+
+PLANTUML_CFG_FILE      = 
 
 # When using plantuml, the specified paths are searched for files specified by
 # the !include statement in a plantuml block.
 
-PLANTUML_INCLUDE_PATH  =
+PLANTUML_INCLUDE_PATH  = 
 
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes

--- a/src/arrayaccess.h
+++ b/src/arrayaccess.h
@@ -62,21 +62,27 @@
  *  defined for SET macros.  If SET_DATA_QBIT were defined as a
  *  compound macro, in analogy to l_setDataQbit(), it requires
  *  surrounding braces:
+ * \code
  *     #define  SET_DATA_QBIT(pdata, n, val) \
  *        {l_uint32 *_TEMP_WORD_PTR_; \
  *         _TEMP_WORD_PTR_ = (l_uint32 *)(pdata) + ((n) >> 3); \
  *         *_TEMP_WORD_PTR_ &= ~(0xf0000000 >> (4 * ((n) & 7))); \
  *         *_TEMP_WORD_PTR_ |= (((val) & 15) << (28 - 4 * ((n) & 7)));}
+ * \endcode
  *  but if used in an if/else
+ * \code
  *      if (x)
  *         SET_DATA_QBIT(...);
  *      else
  *         ...
+ * \endcode
  *  the compiler sees
+ * \code
  *      if (x)
  *         {......};
  *      else
  *         ...
+ * \endcode
  *  The semicolon comes after the brace and will not compile.
  *  This can be fixed in the call by either omitting the semicolon
  *  or requiring another set of braces around SET_DATA_QBIT(), but

--- a/src/blend.c
+++ b/src/blend.c
@@ -2168,10 +2168,10 @@ PIX  *pixd, *pix1, *pix2, *pix3, *pix4;
  * <pre>
  * Notes:
  *      (1) In-place operation.
- *      (2) Maximum fading fraction @maxfade occurs at the edge of the image,
- *          and the fraction goes to 0 at the fractional distance @distfract
- *          from the edge.  @maxfade must be in [0, 1].
- *      (3) @distrfact must be in [0, 1], and typically it would be <= 0.5.
+ *      (2) Maximum fading fraction %maxfade occurs at the edge of the image,
+ *          and the fraction goes to 0 at the fractional distance %distfract
+ *          from the edge.  %maxfade must be in [0, 1].
+ *      (3) %distrfact must be in [0, 1], and typically it would be <= 0.5.
  * </pre>
  */
 l_ok

--- a/src/boxfunc3.c
+++ b/src/boxfunc3.c
@@ -627,6 +627,7 @@ PTAA     *ptaa;
  *          If %pixs is NULL, the dimensions of %pixd are determined by
  *            - %w and %h if both are > 0, or
  *            - the minimum size required using all boxes in %baa.
+ *
  * </pre>
  */
 PIX *
@@ -702,7 +703,7 @@ PIXCMAP  *cmap;
  * <pre>
  * Notes:
  *      (1) All pix in %pixas that are not rgb are converted to rgb.
- *      (2) Each boxa in @baa contains boxes that will be drawn on
+ *      (2) Each boxa in %baa contains boxes that will be drawn on
  *          the corresponding pix in %pixas.
  *      (3) The color of the boxes drawn on each pix are selected with
  *          %colorflag:

--- a/src/boxfunc4.c
+++ b/src/boxfunc4.c
@@ -2302,9 +2302,9 @@ BOX      *box, *boxt;
  * \param[in]    type           L_SELECT_WIDTH, L_SELECT_HEIGHT
  * \param[out]   pdel_evenodd   [optional] average absolute value of
  *                              (even - odd) size pairs
- * \param[out]   prmsdev_even   [optional] rms deviation of even boxes
- * \param[out]   prmsdev_odd    [optional] rms deviation of odd boxes
- * \param[out]   prmsdev_all    [optional] rms deviation of all boxes
+ * \param[out]   prms_even      [optional] rms deviation of even boxes
+ * \param[out]   prms_odd       [optional] rms deviation of odd boxes
+ * \param[out]   prms_all       [optional] rms deviation of all boxes
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/ccbord.c
+++ b/src/ccbord.c
@@ -523,11 +523,13 @@ ccbaGetCount(CCBORDA  *ccba)
  * \brief   ccbaGetCcb()
  *
  * \param[in]    ccba
+ * \param[in]    index
  * \return  ccb, or NULL on error
  *
  * <pre>
  * Notes:
  *      (1) This returns a clone of the ccb; it must be destroyed
+ * </pre>
  */
 CCBORD *
 ccbaGetCcb(CCBORDA  *ccba,

--- a/src/dewarp1.c
+++ b/src/dewarp1.c
@@ -1062,6 +1062,7 @@ dewarpaUseBothArrays(L_DEWARPA  *dewa,
  *           - useboth = 1 (TRUE)
  *          If there are multiple columns, additionally
  *           - check_columns = 0 (FALSE)
+ *
  * </pre>
  */
 l_ok

--- a/src/dewarp2.c
+++ b/src/dewarp2.c
@@ -1352,7 +1352,7 @@ NUMA      *naerr;
  *          disparity only if the absolute value of the fractional
  *          difference equals or exceeds this threshold.
  *      (2) %parity indicates where the binding is: on the left for
- *          %parity == 0 and on the right for @parity == 1.
+ *          %parity == 0 and on the right for %parity == 1.
  *      (3) This takes a 1 bpp %pixb where both vertical and horizontal
  *          disparity have been applied, so the text lines are straight and,
  *          more importantly, the line end points are vertically aligned.

--- a/src/enhance.c
+++ b/src/enhance.c
@@ -1730,7 +1730,7 @@ l_uint32  *data, *line;
  *          and calibration of the printer.  This function can be used
  *          to iteratively match a color print to the original.  On each
  *          iteration, the center offsets are set to the best match so
- *          far, and the @delta increments are typically reduced.
+ *          far, and the %delta increments are typically reduced.
  * </pre>
  */
 PIX *

--- a/src/fhmtauto.c
+++ b/src/fhmtauto.c
@@ -238,9 +238,9 @@ l_int32  ret1, ret2;
  *          the input sela.
  *      (2) The fileindex parameter is inserted into the output
  *          filename, as described below.
- *      (3) If filename == NULL, the output file is fhmtgen.<n>.c,
- *          where <n> is equal to the 'fileindex' parameter.
- *      (4) If filename != NULL, the output file is <filename>.<n>.c.
+ *      (3) If filename == NULL, the output file is fhmtgen.[n].c,
+ *          where [n] is equal to the 'fileindex' parameter.
+ *      (4) If filename != NULL, the output file is [filename].[n].c.
  *      (5) Each sel must have at least one hit.  A sel with only misses
  *          generates code that will abort the operation if it is called.
  * </pre>
@@ -422,9 +422,9 @@ SARRAY  *sa1, *sa2, *sa3;
  *          in the input sela.
  *      (2) The fileindex parameter is inserted into the output
  *          filename, as described below.
- *      (3) If filename == NULL, the output file is fhmtgenlow.<n>.c,
- *          where <n> is equal to the 'fileindex' parameter.
- *      (4) If filename != NULL, the output file is <filename>low.<n>.c.
+ *      (3) If filename == NULL, the output file is fhmtgenlow.[n].c,
+ *          where [n] is equal to the %fileindex parameter.
+ *      (4) If filename != NULL, the output file is [filename]low.[n].c.
  * </pre>
  */
 l_ok

--- a/src/flipdetect.c
+++ b/src/flipdetect.c
@@ -111,8 +111,8 @@
  *
  *  The ascender/descender signal is useful for determining text
  *  orientation in Roman alphabets because the incidence of letters
- *  with straight-line ascenders (b, d, h, k, l, <t>) outnumber
- *  those with descenders (<g>, p, q).  The letters <t> and <g>
+ *  with straight-line ascenders (b, d, h, k, l, 't') outnumber
+ *  those with descenders ('g', p, q).  The letters 't' and 'g'
  *  will respond variably to the filter, depending on the type face.
  *
  *  What about the mirror image situations?  These aren't common

--- a/src/fmorphauto.c
+++ b/src/fmorphauto.c
@@ -274,9 +274,9 @@ l_int32  ret1, ret2;
  *          opening or closing for any of the sels in the input sela.
  *      (2) The fileindex parameter is inserted into the output
  *          filename, as described below.
- *      (3) If filename == NULL, the output file is fmorphgen.<n>.c,
- *          where <n> is equal to the 'fileindex' parameter.
- *      (4) If filename != NULL, the output file is <filename>.<n>.c.
+ *      (3) If filename == NULL, the output file is fmorphgen.[n].c,
+ *          where [n] is equal to the %fileindex parameter.
+ *      (4) If filename != NULL, the output file is [%filename].[n].c.
  * </pre>
  */
 l_ok

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1406,6 +1406,7 @@ PIXCMAP  *cmap;
  * \param[in]    pix  32 bpp rgb
  * \param[in]    pta  arbitrary set of points
  * \param[in]    rval, gval, bval
+ * \param[in]    fract
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/grayquant.c
+++ b/src/grayquant.c
@@ -297,7 +297,7 @@ l_uint32  *lined;
  * \brief   ditherToBinaryLineLow()
  *
  * \param[in]    lined  ptr to beginning of dest line
- *              w   (width of image in pixels
+ * \param[in]    w      width of image in pixels
  * \param[in]    bufs1 buffer of current source line
  * \param[in]    bufs2 buffer of next source line
  * \param[in]    lowerclip lower clip distance to black
@@ -1162,7 +1162,7 @@ l_uint32    *lined;
  * \brief   ditherTo2bppLineLow()
  *
  * \param[in]    lined  ptr to beginning of dest line
- *              w   (width of image in pixels
+ * \param[in]    w      width of image in pixels
  * \param[in]    bufs1 buffer of current source line
  * \param[in]    bufs2 buffer of next source line
  * \param[in]    tabval value to assign for current pixel

--- a/src/jp2kheader.c
+++ b/src/jp2kheader.c
@@ -66,8 +66,8 @@ static const l_int32  MAX_JP2K_HEIGHT = 100000;
  *
  * \param[in]    filename
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pbps ([optional]  bits/sample
+ * \param[out]   ph [optional]
+ * \param[out]   pbps [optional]  bits/sample
  * \param[out]   pspp [optional]  samples/pixel
  * \return  0 if OK, 1 on error
  */
@@ -103,8 +103,8 @@ FILE    *fp;
  *
  * \param[in]    fp file stream opened for read
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pbps ([optional]  bits/sample
+ * \param[out]   ph [optional]
+ * \param[out]   pbps [optional]  bits/sample
  * \param[out]   pspp [optional]  samples/pixel
  * \return  0 if OK, 1 on error
  */
@@ -144,8 +144,8 @@ l_int32  nread;
  * \param[in]    data
  * \param[in]    size at least 80
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pbps ([optional]  bits/sample
+ * \param[out]   ph [optional]
+ * \param[out]   pbps [optional]  bits/sample
  * \param[out]   pspp [optional]  samples/pixel
  * \return  0 if OK, 1 on error
  *

--- a/src/jpegio.c
+++ b/src/jpegio.c
@@ -497,8 +497,8 @@ jmp_buf                        jmpbuf;  /* must be local to the function */
  *
  * \param[in]    filename
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pspp ([optional]  samples/pixel
+ * \param[out]   ph [optional]
+ * \param[out]   pspp  [optional]  samples/pixel
  * \param[out]   pycck [optional]  1 if ycck color space; 0 otherwise
  * \param[out]   pcmyk [optional]  1 if cmyk color space; 0 otherwise
  * \return  0 if OK, 1 on error
@@ -539,8 +539,8 @@ FILE    *fp;
  *
  * \param[in]    fp file stream
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pspp ([optional]  samples/pixel
+ * \param[out]   ph [optional]
+ * \param[out]   pspp  [optional]  samples/pixel
  * \param[out]   pycck [optional]  1 if ycck color space; 0 otherwise
  * \param[out]   pcmyk [optional]  1 if cmyk color space; 0 otherwise
  * \return  0 if OK, 1 on error

--- a/src/list.c
+++ b/src/list.c
@@ -135,12 +135,12 @@
  *      When you are only applying some function to each element
  *      in a list, you can go either forwards or backwards.
  *      To run through a list forwards, use:
- *
+ * \code
  *          for (elem = head; elem; elem = nextelem) {
  *              nextelem = elem->next;   (in case we destroy elem)
  *              <do something with elem->data>
  *          }
- *
+ * \endcode
  *      To run through a list backwards, find the tail and use:
  *
  *          for (elem = tail; elem; elem = prevelem) {
@@ -151,7 +151,7 @@
  *      Even though these patterns are very simple, they are so common
  *      that we've provided macros for them in list.h.  Using the
  *      macros, this becomes:
- *
+ * \code
  *          L_BEGIN_LIST_FORWARD(head, elem)
  *              <do something with elem->data>
  *          L_END_LIST
@@ -159,7 +159,7 @@
  *          L_BEGIN_LIST_REVERSE(tail, elem)
  *              <do something with elem->data>
  *          L_END_LIST
- *
+ * \endcode
  *      Note again that with macros, the application programmer does
  *      not need to refer explicitly to next and prev fields.  Also,
  *      in the reverse case, note that we do not explicitly
@@ -169,23 +169,23 @@
  *
  *      Some special cases are simpler.  For example, when
  *      removing all items from the head of the list, you can use
- *
+ * \code
  *          while (head) {
  *              obj = listRemoveFromHead(&head);
  *              <do something with obj>
  *          }
- *
+ * \endcode
  *      Removing successive elements from the tail is equally simple:
- *
+ * \code
  *          while (tail) {
  *              obj = listRemoveFromTail(&head, &tail);
  *              <do something with obj>
  *          }
- *
+ * \endcode
  *      When removing an arbitrary element from a list, use
- *
+ * \code
  *              obj = listRemoveElement(&head, elem);
- *
+ * \endcode
  *      All the listRemove*() functions hand you the object,
  *      destroy the list cell to which it was attached, and
  *      reset the list pointers if necessary.
@@ -382,11 +382,12 @@ DLLIST  *cell, *head, *tail;
  *          head and elem must be null.
  *      (2) If you are searching through a list, looking for a condition
  *          to add an element, you can do something like this:
+ * \code
  *            L_BEGIN_LIST_FORWARD(head, elem)
  *                <identify an elem to insert before>
  *                listInsertBefore(&head, elem, data);
  *            L_END_LIST
- *
+ * \endcode
  * </pre>
  */
 l_ok
@@ -446,10 +447,12 @@ DLLIST  *cell, *head;
  *          in the call to allow "consing" up from NULL.
  *      (2) If you are searching through a list, looking for a condition
  *          to add an element, you can do something like this:
+ * \code
  *            L_BEGIN_LIST_FORWARD(head, elem)
  *                <identify an elem to insert after>
  *                listInsertAfter(&head, elem, data);
  *            L_END_LIST
+ * \endcode
  * </pre>
  */
 l_ok

--- a/src/numafunc2.c
+++ b/src/numafunc2.c
@@ -684,6 +684,7 @@ NUMA       *na1, *nad;
  *          window of the mean square difference of the pixel value
  *          from the mean:
  *                <(x - <x>)*(x - <x>)> = <x*x> - <x>*<x>
+ *
  * </pre>
  */
 l_ok
@@ -2530,7 +2531,7 @@ NUMA      *nav, *nad;
  * \param[in]    nas input values
  * \param[in]    minreversal relative amount to resolve peaks and valleys
  * \param[out]   pnr [optional] number of reversals
- *           [out]   pnrpl ([optional] reversal density: reversals/length
+ * \param[out]   pnrpl ([optional] reversal density: reversals/length
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/pageseg.c
+++ b/src/pageseg.c
@@ -1748,7 +1748,7 @@ PIX     *pix1, *pix2, *pix3, *pix4, *pix5, *pix6, *pix7, *pix8, *pix9;
  *                          300 ppi; use 0 to skip scaling.
  * \return  pixd if OK, NULL on error
  *
- * </pre>
+ * <pre>
  * Notes:
  *      (1) This handles some common pre-processing operations,
  *          where the page segmentation algorithm takes a 1 bpp image.

--- a/src/pdfio1.c
+++ b/src/pdfio1.c
@@ -35,7 +35,9 @@
  *    |=============================================================|
  *    | Some of these functions require libtiff, libjpeg, and libz  |
  *    | If you do not have these libraries, you must set            |
+ *    | \code                                                       |
  *    |      #define  USE_PDFIO     0                               |
+ *    | \endcode                                                    |
  *    | in environ.h.  This will link pdfiostub.c                   |
  *    |=============================================================|
  *

--- a/src/pdfio2.c
+++ b/src/pdfio2.c
@@ -1631,6 +1631,7 @@ SARRAY  *sa;
  *          that the data is to be interpreted as big-endian, 4 bytes
  *          at a time.  For ascii, the first two bytes are 0 and the
  *          last two bytes are less than 0x80.
+ * </pre>
  */
 static char  *
 generateEscapeString(const char  *str)

--- a/src/pix1.c
+++ b/src/pix1.c
@@ -1107,7 +1107,7 @@ pixSetDimensions(PIX     *pix,
  * \brief   pixCopyDimensions()
  *
  * \param[in]    pixd
- * \param[in]    pixd
+ * \param[in]    pixs
  * \return  0 if OK, 1 on error
  */
 l_ok

--- a/src/pix3.c
+++ b/src/pix3.c
@@ -1059,7 +1059,7 @@ PIX       *pixd;
  *          example, a mask that discriminates against red and in favor
  *          of blue will have rc < 0.0 and bc > 0.0.
  *      (3) To make the result independent of intensity (the 'V' in HSV),
- *          select coefficients so that @thresh = 0.  Then the result
+ *          select coefficients so that %thresh = 0.  Then the result
  *          is not changed when all components are multiplied by the
  *          same constant (as long as nothing saturates).  This can be
  *          useful if, for example, the illumination is not uniform.

--- a/src/pixabasic.c
+++ b/src/pixabasic.c
@@ -580,6 +580,7 @@ pixaExtendArray(PIXA  *pixa)
  * \brief   pixaExtendArrayToSize()
  *
  * \param[in]    pixa
+ * \param[in]    size
  * \return  0 if OK; 1 on error
  *
  * <pre>
@@ -633,6 +634,7 @@ pixaGetCount(PIXA  *pixa)
  * \brief   pixaChangeRefcount()
  *
  * \param[in]    pixa
+ * \param[in]    delta
  * \return  0 if OK, 1 on error
  */
 l_ok

--- a/src/pixafunc1.c
+++ b/src/pixafunc1.c
@@ -2588,7 +2588,7 @@ PIXA    *pixa1, *pixad;
  * \param[in]    pixa2
  * \param[in]    maxdist
  * \param[out]   pnaindex    [optional] index array of correspondences
- *           [out]   psame (1 if equal; 0 otherwise
+ * \param[out]   psame (1 if equal; 0 otherwise
  * \return  0 if OK, 1 on error
  *
  * <pre>

--- a/src/pixalloc.c
+++ b/src/pixalloc.c
@@ -141,7 +141,7 @@ static L_PIX_MEM_STORE  *CustomPMS = NULL;
  *
  * \param[in]    minsize of data chunk that can be supplied by pms
  * \param[in]    smallest bytes of the smallest pre-allocated data chunk.
- *              numalloc (array with the number of data chunks for each
+ * \param[in]    numalloc array with the number of data chunks for each
  *                        size that are in the memory store
  * \param[in]    logfile use for debugging; null otherwise
  * \return  0 if OK, 1 on error

--- a/src/pixarith.c
+++ b/src/pixarith.c
@@ -1424,6 +1424,7 @@ PIX        *pixd;
  *          Otherwise, the product will overflow a uint8.  In use, factor
  *          is the same for all pixels in a pix.
  *      (2) No scaling is performed on the transparency ("A") component.
+ * </pre>
  */
 l_uint32
 linearScaleRGBVal(l_uint32   sval,

--- a/src/pixcomp.c
+++ b/src/pixcomp.c
@@ -2097,7 +2097,6 @@ L_PTRA   *pa_data;
  * \brief   pixacompFastConvertToPdfData()
  *
  * \param[in]    pixac containing images all at the same resolution
- * \param[in]    res input resolution of all images
  * \param[in]    title [optional] pdf title
  * \param[out]   pdata output pdf data (of all images
  * \param[out]   pnbytes size of output pdf data

--- a/src/pixconv.c
+++ b/src/pixconv.c
@@ -3680,7 +3680,7 @@ pixRemoveAlpha(PIX *pixs)
  * \brief   pixAddAlphaTo1bpp()
  *
  * \param[in]    pixd    [optional] 1 bpp, can be null or equal to pixs
- *               pixs    1 bpp
+ * \param[in]    pixs    1 bpp
  * \return  pixd 1 bpp with colormap and non-opaque alpha,
  *                    or NULL on error
  *

--- a/src/pngio.c
+++ b/src/pngio.c
@@ -499,8 +499,8 @@ PIXCMAP     *cmap;
  *
  * \param[in]    filename
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pbps ([optional]  bits/sample
+ * \param[out]   ph ([optional]
+ * \param[out]   pbps ([optional]  bits/sample
  * \param[out]   pspp [optional]  samples/pixel
  * \param[out]   piscmap [optional]
  * \return  0 if OK, 1 on error
@@ -546,8 +546,8 @@ FILE    *fp;
  *
  * \param[in]    fp file stream
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pbps ([optional]  bits/sample
+ * \param[out]   ph ([optional]
+ * \param[out]   pbps ([optional]  bits/sample
  * \param[out]   pspp [optional]  samples/pixel
  * \param[out]   piscmap [optional]
  * \return  0 if OK, 1 on error
@@ -594,8 +594,8 @@ l_uint8  data[40];
  * \param[in]    data
  * \param[in]    size 40 bytes is sufficient
  * \param[out]   pw [optional]
- *           [out]   ph ([optional]
- *           [out]   pbps ([optional]  bits/sample
+ * \param[out]   ph ([optional]
+ * \param[out]   pbps ([optional]  bits/sample
  * \param[out]   pspp [optional]  samples/pixel
  * \param[out]   piscmap [optional]  input NULL to ignore
  * \return  0 if OK, 1 on error

--- a/src/psio1.c
+++ b/src/psio1.c
@@ -33,7 +33,9 @@
  *    |=============================================================|
  *    | Some of these functions require libtiff, libjpeg and libz.  |
  *    | If you do not have these libraries, you must set            |
+ *    | \code                                                       |
  *    |     #define  USE_PSIO     0                                 |
+ *    | \endcode                                                    |
  *    | in environ.h.  This will link psio1stub.c                   |
  *    |=============================================================|
  *
@@ -182,7 +184,7 @@ SARRAY  *sa;
 
 
 /*
- 
+
  * \brief    sarrayConvertFilesToPS()
  *
  * \param[in]  sarray   of full path names
@@ -709,7 +711,7 @@ PIX       *pixmi, *pixmis, *pixt, *pixg, *pixsc, *pixb, *pixc;
  *
  * \param[in]     pixb      [optional] 1 bpp mask; typically for text
  * \param[in]     pixc      [optional] 8 or 32 bpp image regions
- * \param[in]     scale     scale factor for rendering pixb, relative to pixc; 
+ * \param[in]     scale     scale factor for rendering pixb, relative to pixc;
  *                          typ. 4.0
  * \param[in]     pageno    page number in set; use 1 for new output file
  * \param[in]     fileout   output ps file

--- a/src/psio2.c
+++ b/src/psio2.c
@@ -33,7 +33,9 @@
  *    |=============================================================|
  *    | Some of these functions require libtiff, libjpeg and libz.  |
  *    | If you do not have these libraries, you must set            |
+ *    | \code                                                       |
  *    |     #define  USE_PSIO     0                                 |
+ *    | \endcode                                                    |
  *    | in environ.h.  This will link psio2stub.c                   |
  *    |=============================================================|
  *

--- a/src/ptafunc1.c
+++ b/src/ptafunc1.c
@@ -2163,7 +2163,7 @@ PTAA      *ptaa;
  *
  * \param[in]    pixs any depth
  * \param[in]    x, y pixel from which we search for nearest neighbors
- *              conn (4 or 8 connectivity
+ * \param[in]    conn (4 or 8 connectivity)
  * \return  pta, or NULL on error
  *
  * <pre>

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -147,7 +147,7 @@ l_rbtreeCreate(l_int32  keytype)
  * \brief   l_rbtreeLookup()
  *
  * \param[in]   t        rbtree, including root node
- * \param[in    key      find a node with this key
+ * \param[in]   key      find a node with this key
  * \return    &value     a pointer to a union, if the node exists; else NULL
  */
 RB_TYPE *
@@ -271,7 +271,7 @@ node  *n, *child;
 /*!
  * \brief   l_rbtreeDestroy()
  *
- * \param[in]   &t     ptr to rbtree
+ * \param[in]   pt     ptr to rbtree
  * \return      void
  *
  * <pre>
@@ -446,7 +446,7 @@ l_rbtreeGetPrev(L_RBTREE_NODE  *n)
 /*!
  * \brief   l_rbtreeGetCount()
  *
- * \param[in   t      rbtree
+ * \param[in]  t      rbtree
  * \return     count  the number of nodes in the tree, or 0 on error
  */
 l_int32

--- a/src/readfile.c
+++ b/src/readfile.c
@@ -1076,7 +1076,7 @@ extern const char *ImageFileFormatExtensions[];
  * \brief   writeImageFileInfo()
  *
  * \param[in]    filename    input file
- * \param[in]    fp          output file stream
+ * \param[in]    fpout       output file stream
  * \param[in]    headeronly  1 to read only the header; 0 to read both
  *                           the header and the input file
  * \return  0 if OK; 1 on error

--- a/src/recogident.c
+++ b/src/recogident.c
@@ -697,8 +697,8 @@ PIX       *pix1, *pix2;
  *                          are vertically aligned
  * \param[in]    tab8 [optional] sum tab for ON pixels in byte; can be NULL
  * \param[out]   pdelx [optional] best x shift of pix2 relative to pix1
- *           [out]   pdely ([optional] best y shift of pix2 relative to pix1
- *           [out]   pscore ([optional] maximum score found; can be NULL
+ * \param[out]   pdely ([optional] best y shift of pix2 relative to pix1
+ * \param[out]   pscore ([optional] maximum score found; can be NULL
  * \param[in]    debugflag <= 0 to skip; positive to generate output.
  *                         The integer is used to label the debug image.
  * \return  0 if OK, 1 on error

--- a/src/recogtrain.c
+++ b/src/recogtrain.c
@@ -1482,6 +1482,7 @@ L_RECOG   *recog;
  *      (2) Identification occurs in scaled mode (typically with h = 40),
  *          optionally using a width-normalized line images derived
  *          from those in %pixas.
+ *
  * </pre>
  */
 PIXA  *
@@ -1573,7 +1574,7 @@ PIXA      *pixa1, *pixa2, *pixa3, *pixad;
 /*!
  * \brief   recogPadDigitTrainingSet()
  *
- * \param[in/out]   precog   trained; if padding is needed, it is replaced
+ * \param[in,out]   precog   trained; if padding is needed, it is replaced
  *                           by a a new padded recog
  * \param[in]       scaleh   must be > 0; suggest ~40.
  * \param[in]       linew    use 0 for original scanned images
@@ -1586,6 +1587,7 @@ PIXA      *pixa1, *pixa2, *pixa3, *pixad;
  *          padded appropriately with templates from a boot recognizer,
  *          and set up with correlation templates derived from
  *          %scaleh and %linew.
+ *
  * </pre>
  */
 l_ok
@@ -1870,6 +1872,7 @@ l_int32  ret;
  *         input bitmaps or images with fixed line widths.  To use the
  *         input bitmaps, set %linew = 0; otherwise, set %linew to the
  *         desired line width.
+ *
  * </pre>
  */
 L_RECOG  *
@@ -2251,6 +2254,7 @@ PIXA      *pixa1;
  *          - The outlier sample
  *          - The average template from the same class
  *          - The average class template that best matched the outlier sample
+ *
  * </pre>
  */
 static PIX  *

--- a/src/regutils.c
+++ b/src/regutils.c
@@ -492,8 +492,8 @@ l_int32  w, h, factor, similar;
  *           * "compare": compares %localname contents with the golden file
  *           * "display": makes the %localname file but does no comparison
  *      (2) The canonical format of the golden filenames is:
- *            /tmp/lept/golden/<root of main name>_golden.<index>.
- *                                                       <ext of localname>
+ *            /tmp/lept/golden/[root of main name]_golden.[index].
+ *                                                       [ext of localname]
  *          e.g.,
  *             /tmp/lept/golden/maze_golden.0.png
  *          It is important to add an extension to the local name, because
@@ -601,8 +601,8 @@ PIX     *pix1, *pix2;
  * Notes:
  *      (1) This only does something in "compare" mode.
  *      (2) The canonical format of the golden filenames is:
- *            /tmp/lept/golden/<root of main name>_golden.<index>.
- *                                                      <ext of localname>
+ *            /tmp/lept/golden/[root of main name]_golden.[index].
+ *                                                      [ext of localname]
  *          e.g.,
  *            /tmp/lept/golden/maze_golden.0.png
  * </pre>
@@ -691,7 +691,7 @@ SARRAY  *sa;
  *             (b) make a local file and "compare" with the golden file
  *             (c) make a local file and "display" the results
  *      (2) The canonical format of the local filename is:
- *            /tmp/lept/regout/<root of main name>.<count>.<format extension>
+ *            /tmp/lept/regout/[root of main name].[count].[format extension]
  *          e.g., for scale_reg,
  *            /tmp/lept/regout/scale.0.png
  *          The golden file name mirrors this in the usual way.
@@ -742,7 +742,7 @@ char  namebuf[256];
  *
  * \param[in]    rp      regtest parameters
  * \param[in]    data    to be written
- * \param[in]    size    of data to be written
+ * \param[in]    nbytes  of data to be written
  * \param[in]    ext     filename extension (e.g.: "ba", "pta")
  * \return  0 if OK, 1 on error a failure in comparison is not an error
  *
@@ -754,7 +754,7 @@ char  namebuf[256];
  *             (b) make a local file and "compare" with the golden file
  *             (c) make a local file and "display" the results
  *      (2) The canonical format of the local filename is:
- *            /tmp/lept/regout/<root of main name>.<count>.<ext>
+ *            /tmp/lept/regout/[root of main name].[count].[ext]
  *          e.g., for the first boxaa in quadtree_reg,
  *            /tmp/lept/regout/quadtree.0.baa
  *          The golden file name mirrors this in the usual way.
@@ -814,6 +814,8 @@ char  namebuf[256];
  *          written file.  The latter case lets you read a pix from a
  *          file that has just been written with regTestWritePixAndCheck(),
  *          which is useful for testing formatted read/write functions.
+ *
+ * </pre>
  */
 char *
 regTestGenLocalFilename(L_REGPARAMS  *rp,

--- a/src/scale1.c
+++ b/src/scale1.c
@@ -1747,9 +1747,9 @@ PIX       *pixs, *pixd;
 /*!
  * \brief   pixScaleSmoothToSize()
  *
- * \param[in]    pix 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
- * \param[in]    wd  target width; use 0 if using height as target
- * \param[in]    hd  target height; use 0 if using width as target
+ * \param[in]    pixs 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
+ * \param[in]    wd   target width; use 0 if using height as target
+ * \param[in]    hd   target height; use 0 if using width as target
  * \return  pixd, or NULL on error
  *
  * <pre>
@@ -2037,9 +2037,9 @@ PIX       *pixs, *pixd;
 /*!
  * \brief   pixScaleAreaMapToSize()
  *
- * \param[in]    pix 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
- * \param[in]    wd  target width; use 0 if using height as target
- * \param[in]    hd  target height; use 0 if using width as target
+ * \param[in]    pixs 2, 4, 8 or 32 bpp; and 2, 4, 8 bpp with colormap
+ * \param[in]    wd   target width; use 0 if using height as target
+ * \param[in]    hd   target height; use 0 if using width as target
  * \return  pixd, or NULL on error
  *
  * <pre>

--- a/src/scale2.c
+++ b/src/scale2.c
@@ -1190,7 +1190,8 @@ PIX       *pixd;
  * \brief   pixScaleGrayRankCascade()
  *
  * \param[in]    pixs 8 bpp, not cmapped
- * \param[in]    level1, ... level4 rank thresholds, in set {0, 1, 2, 3, 4}
+ * \param[in]    level1, level2, level3, level4 rank thresholds,
+ *                                              in set {0, 1, 2, 3, 4}
  * \return  pixd 8 bpp, downscaled by up to 16x
  *
  * <pre>

--- a/src/stringcode.c
+++ b/src/stringcode.c
@@ -148,8 +148,8 @@ static char *l_genDescrString(const char *filein, l_int32 ifunc, l_int32 itype);
  * Notes:
  *      (1) This struct exists to build two files containing code for
  *          any number of data objects.  The two files are named
- *             autogen.<fileno>.c
- *             autogen.<fileno>.h
+ *             autogen.[fileno].c
+ *             autogen.[fileno].h
  * </pre>
  */
 L_STRCODE *
@@ -215,8 +215,8 @@ L_STRCODE  *strcode;
  *      (1) The %filein has one filename on each line.
  *          Comment lines begin with "#".
  *      (2) The output is 2 files:
- *             autogen.<fileno>.c
- *             autogen.<fileno>.h
+ *             autogen.[fileno].c
+ *             autogen.[fileno].h
  * </pre>
  */
 l_ok
@@ -278,8 +278,8 @@ L_STRCODE   *strcode;
  * <pre>
  * Notes:
  *      (1) The generated function name is
- *            l_autodecode_<fileno>()
- *          where <fileno> is the index label for the pair of output files.
+ *            l_autodecode_[fileno]()
+ *          where [fileno] is the index label for the pair of output files.
  *      (2) To deserialize this data, the function is called with the
  *          argument 'ifunc', which increments each time strcodeGenerate()
  *          is called.
@@ -519,6 +519,7 @@ SARRAY     *sa1, *sa2, *sa3;
  *      (1) For example, if %field == L_STR_NAME, and the file is a serialized
  *          pixa, this will return "Pixa", the name of the struct.
  *      (2) Caller must free the returned string.
+ * </pre>
  */
 l_int32
 l_getStructStrFromFile(const char  *filename,

--- a/src/strokes.c
+++ b/src/strokes.c
@@ -289,7 +289,7 @@ PIXA      *pixad;
 /*!
  * \brief   pixModifyStrokeWidth()
  *
- * \param[in]   pixa  of 1 bpp pix
+ * \param[in]   pixs  of 1 bpp pix
  * \param[in]   width  measured average stroke width
  * \param[in]   targetw  desired stroke width
  * \return  pix  with modified stroke width, or NULL on error

--- a/src/tiffio.c
+++ b/src/tiffio.c
@@ -831,7 +831,7 @@ TIFF  *tif;
  *                         IFF_TIFF_RLE, IFF_TIFF_PACKBITS: for 1 bpp only
  *                         IFF_TIFF_G4 and IFF_TIFF_G3: for 1 bpp only
  *                         IFF_TIFF_LZW, IFF_TIFF_ZIP: for any image
- *               natags ([optional] NUMA of custom tiff tags
+ * \param[in]    natags [optional] NUMA of custom tiff tags
  * \param[in]    savals [optional] SARRAY of values
  * \param[in]    satypes [optional] SARRAY of types
  * \param[in]    nasizes [optional] NUMA of sizes
@@ -1146,7 +1146,7 @@ l_uint32   uval, uval2;
  * \brief   pixReadFromMultipageTiff()
  *
  * \param[in]      fname     filename
- * \param[in,out]  &offset   set offset to 0 for first image
+ * \param[in,out]  poffset   set offset to 0 for first image
  * \return  pix, or NULL on error or if previous call returned the last image
  *
  * <pre>
@@ -1271,7 +1271,7 @@ TIFF    *tif;
 /*!
  * \brief   pixaWriteMultipageTiff()
  *
- * \param[in]    filename   input tiff file
+ * \param[in]    fname      input tiff file
  * \param[in]    pixa       any depth; colormap will be removed
  * \return  0 if OK, 1 on error
  *
@@ -2472,7 +2472,7 @@ TIFF     *tif;
  *
  * \param[in]    cdata      const; tiff-encoded
  * \param[in]    size       size of cdata
- * \param[in,out]  &offset  set offset to 0 for first image
+ * \param[in,out]  poffset  set offset to 0 for first image
  * \return  pix, or NULL on error or if previous call returned the last image
  *
  * <pre>
@@ -2572,8 +2572,8 @@ PIXA   *pixa;
 /*!
  * \brief   pixaWriteMemMultipageTiff()
  *
- * \param[in]    cdata     const; tiff-encoded
- * \param[in]    size      size of cdata
+ * \param[in]    pdata     const; tiff-encoded
+ * \param[in]    psize     size of data
  * \param[in]    pixa      any depth; colormap will be removed
  * \return  0 if OK, 1 on error
  *

--- a/src/utils2.c
+++ b/src/utils2.c
@@ -120,7 +120,7 @@
   *     and genPathname(), all input pathnames must have unix separators.
  *  (2) On Windows, when you specify a read or write to "/tmp/...",
  *      the filename is rewritten to use the Windows temp directory:
- *         /tmp  ==>   <Temp>...    (windows)
+ *         /tmp  ==>   [Temp]...    (windows)
  *  (3) This filename rewrite, along with the conversion from unix
  *      to windows pathnames, happens in genPathname().
  *  (4) Use fopenReadStream() and fopenWriteStream() to open files,
@@ -1192,11 +1192,15 @@ FILE     *fp;
  *          because it does not require seeking within the file.
  *      (3) For example, you can read an image from stdin into memory
  *          using shell redirection, with one of these shell commands:
+ * \code
  *             cat <imagefile> | readprog
  *             readprog < <imagefile>
+ * \endcode
  *          where readprog is:
+ * \code
  *             l_uint8 *data = l_binaryReadStream(stdin, &nbytes);
  *             Pix *pix = pixReadMem(data, nbytes);
+ * \endcode
  * </pre>
  */
 l_uint8 *
@@ -1591,7 +1595,7 @@ FILE  *fp;
  *      (1) This should be used whenever you want to run fopen() to
  *          read from a stream.  Never call fopen() directory.
  *      (2) This handles the temp directory pathname conversion on windows:
- *              /tmp  ==>  <Windows Temp directory>
+ *              /tmp  ==>  [Windows Temp directory]
  * </pre>
  */
 FILE *
@@ -1634,7 +1638,7 @@ FILE  *fp;
  *      (1) This should be used whenever you want to run fopen() to
  *          write or append to a stream.  Never call fopen() directory.
  *      (2) This handles the temp directory pathname conversion on windows:
- *              /tmp  ==>  <Windows Temp directory>
+ *              /tmp  ==>  [Windows Temp directory]
  * </pre>
  */
 FILE *
@@ -1878,7 +1882,7 @@ lept_free(void *ptr)
  *      (2) This makes any subdirectories of /tmp that are required.
  *      (3) The root temp directory is:
  *            /tmp    (unix)  [default]
- *            <Temp>  (windows)
+ *            [Temp]  (windows)
  * </pre>
  */
 l_int32
@@ -1950,7 +1954,7 @@ l_uint32  attributes;
  *      (2) This removes all files from the specified subdirectory of
  *          the root temp directory:
  *            /tmp    (unix)
- *            <Temp>  (windows)
+ *            [Temp]  (windows)
  *          and then removes the subdirectory.
  *      (3) The combination
  *            lept_rmdir(subdir);
@@ -2028,8 +2032,8 @@ char    *newpath;
  *      (1) Always use unix pathname separators.
  *      (2) By calling genPathname(), if the pathname begins with "/tmp"
  *          this does an automatic directory translation on windows
- *          to a path in the windows <Temp> directory:
- *             "/tmp"  ==>  <Temp> (windows)
+ *          to a path in the windows [Temp] directory:
+ *             "/tmp"  ==>  [Temp] (windows)
  * </pre>
  */
 void
@@ -2083,8 +2087,8 @@ char  *realdir;
  *      (3) Use unix pathname separators.
  *      (4) By calling genPathname(), if the pathname begins with "/tmp"
  *          this does an automatic directory translation on windows
- *          to a path in the windows <Temp> directory:
- *             "/tmp"  ==>  <Temp> (windows)
+ *          to a path in the windows [Temp] directory:
+ *             "/tmp"  ==>  [Temp] (windows)
  *      (5) Error conditions:
  *            * returns -1 if the directory is not found
  *            * returns the number of files (> 0) that it was unable to remove.
@@ -2136,8 +2140,8 @@ SARRAY  *sa;
  * <pre>
  * Notes:
  *      (1) By calling genPathname(), this does an automatic directory
- *          translation on windows to a path in the windows <Temp> directory:
- *             "/tmp/..."  ==>  <Temp>/... (windows)
+ *          translation on windows to a path in the windows [Temp] directory:
+ *             "/tmp/..."  ==>  [Temp]/... (windows)
  * </pre>
  */
 l_int32
@@ -2226,8 +2230,8 @@ l_int32  ret;
  *      (6) Reminders:
  *          (a) specify files using unix pathnames
  *          (b) for windows, translates
- *                 /tmp  ==>  <Temp>
- *              where <Temp> is the windows temp directory
+ *                 /tmp  ==>  [Temp]
+ *              where [Temp] is the windows temp directory
  *      (7) Examples:
  *          * newdir = NULL,    newtail = NULL    ==> /tmp/src-tail
  *          * newdir = NULL,    newtail = abc     ==> /tmp/abc
@@ -2324,8 +2328,8 @@ l_int32  ret;
  *      (6) Reminders:
  *          (a) specify files using unix pathnames
  *          (b) for windows, translates
- *                 /tmp  ==>  <Temp>
- *              where <Temp> is the windows temp directory
+ *                 /tmp  ==>  [Temp]
+ *              where [Temp] is the windows temp directory
  *      (7) Examples:
  *          * newdir = NULL,    newtail = NULL    ==> /tmp/src-tail
  *          * newdir = NULL,    newtail = abc     ==> /tmp/abc
@@ -2693,7 +2697,7 @@ L_BYTEA  *ba;
  * <pre>
  * Notes:
  *      (1) Use unix pathname separators
- *      (2) Allocates a new string:  <basedir>/<subdirs>
+ *      (2) Allocates a new string:  [basedir]/[subdirs]
  * </pre>
  */
 char *
@@ -2797,8 +2801,8 @@ size_t   len;
  *              temp directory is used.
  *      (2) On windows, if the root of %dir is '/tmp', this does a name
  *          translation:
- *             "/tmp"  ==>  <Temp> (windows)
- *          where <Temp> is the windows temp directory.
+ *             "/tmp"  ==>  [Temp] (windows)
+ *          where [Temp] is the windows temp directory.
  *      (3) On unix, the TMPDIR variable is ignored.  No rewriting
  *          of temp directories is permitted.
  *      (4) There are four cases for the input:
@@ -2905,8 +2909,8 @@ l_int32  dirlen, namelen, size;
  *      (2) Caller allocates %result, large enough to hold the path,
  *          which is:
  *            /tmp/%subdir       (unix)
- *            <Temp>/%subdir     (windows)
- *          where <Temp> is a path on windows determined by GenTempPath()
+ *            [Temp]/%subdir     (windows)
+ *          where [Temp] is a path on windows determined by GenTempPath()
  *          and %subdir is in general a set of nested subdirectories:
  *            dir1/dir2/.../dirN
  *          which in use would not typically exceed 2 levels.
@@ -3005,7 +3009,7 @@ size_t  len;
  *               "/tmp/lept.XXXXXX",
  *          where each X is a random character.
  *      (2) On windows, this makes a filename of the form
- *               "/<Temp>/lp.XXXXXX".
+ *               "/[Temp]/lp.XXXXXX".
  *      (3) On all systems, this fails if the file is not writable.
  *      (4) Safest usage is to write to a subdirectory in debug code.
  *      (5) The returned filename must be freed by the caller, using lept_free.
@@ -3015,6 +3019,7 @@ size_t  len;
  *      (7) On unix, whenever possible use tmpfile() instead.  tmpfile()
  *          hides the file name, returns a stream opened for write,
  *          and deletes the temp file when the stream is closed.
+ * </pre>
  */
 char *
 l_makeTempFilename()


### PR DESCRIPTION
After temporarily seting `WARN_IF_UNDOCUMENTED = NO` in `Doxyfile`,
the list of warnings and errors was not too big.

The most prevalent issue is the usage of `<` and `>` in comments,
because they are interpreted as HTML tag angle brackets.

In cases where replacing them with square brackets seems to
be acceptable, I did that. In other cases, like in formulas
where the notation `<x>` means average, they produce warnings.

The other changes were mostly missing `</pre>` tags, or missing
`\param`, or wrong named parameters.