### PR TITLE
boxfunc5: Fix loop count condition

### DIFF
--- a/src/boxfunc5.c
+++ b/src/boxfunc5.c
@@ -1806,7 +1806,7 @@ NUMA    *nadelw, *nadelh;
     n = boxaGetCount(boxas);
     nadelw = numaCreate(n);
     nadelh = numaCreate(n);
-    for (i = 0; i < 0; i++) {
+    for (i = 0; i < n; i++) {
         boxaGetBoxGeometry(boxas, i, NULL, NULL, &bw, &bh);
         if (bw == 0 || bh == 0) {  /* invalid box */
             numaAddNumber(nadelw, 0);


### PR DESCRIPTION
This also fixes a warning from LGTM:

    Comparison is always false because i >= 0.

Signed-off-by: Stefan Weil <sw@weilnetz.de>