### PR TITLE
Replace insecure gmtime

### DIFF
--- a/src/utils1.c
+++ b/src/utils1.c
@@ -1119,7 +1119,11 @@ struct tm  *tptr;
            itself whether DST is in effect.  This is necessary because
            "gmtime" always sets "tm_isdst" to 0, which would tell
            "mktime" to presume that DST is not in effect. */
-    tptr = gmtime(&ut);
+#ifdef _WIN32
+    gmtime_s(tptr, &ut);
+#else
+    gmtime_r(&ut, tptr);
+#endif
     tptr->tm_isdst = -1;
     lt = mktime(tptr);
 


### PR DESCRIPTION
This fixes an error from LGTM:

    Call to gmtime is potentially dangerous

Signed-off-by: Stefan Weil <sw@weilnetz.de>