### PR TITLE
Fix format strings for size_t arguments

### DIFF
--- a/src/utils1.c
+++ b/src/utils1.c
@@ -529,7 +529,7 @@ l_uint8  *datain, *dataout;
 
     datain = l_binaryRead(filein, &inbytes);
     if (start + nbytes > inbytes)
-        L_WARNING("start + nbytes > length(filein) = %lu\n", procName, inbytes);
+        L_WARNING("start + nbytes > length(filein) = %zu\n", procName, inbytes);
 
     if (!newdata) newsize = 0;
     outbytes = inbytes - nbytes + newsize;

--- a/src/webpanimio.c
+++ b/src/webpanimio.c
@@ -263,7 +263,7 @@ WebPPicture             frame;
 
     *pencdata = (l_uint8 *)webp_data.bytes;
     *pencsize = webp_data.size;
-    L_INFO("data size = %lu\n", procName, webp_data.size);
+    L_INFO("data size = %zu\n", procName, webp_data.size);
     return 0;
 }
 


### PR DESCRIPTION
This fixes warnings from clang and MS VC.

Signed-off-by: Stefan Weil <sw@weilnetz.de>