### PR TITLE
solve 'getcwd' is deprecated: The POSIX name for this it…

### DIFF
--- a/prog/files_reg.c
+++ b/prog/files_reg.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #ifndef _MSC_VER
 #include <unistd.h>
+#define getcwd _getcwd  // fix MSVC warning
 #else
 #include <direct.h>
 #endif  /* !_MSC_VER */

--- a/prog/files_reg.c
+++ b/prog/files_reg.c
@@ -37,9 +37,9 @@
 #include <string.h>
 #ifndef _MSC_VER
 #include <unistd.h>
-#define getcwd _getcwd  // fix MSVC warning
 #else
 #include <direct.h>
+#define getcwd _getcwd  // fix MSVC warning
 #endif  /* !_MSC_VER */
 
 void TestPathJoin(L_REGPARAMS *rp, const char *first, const char *second,

--- a/src/utils2.c
+++ b/src/utils2.c
@@ -182,6 +182,7 @@
 #ifdef _MSC_VER
 #include <process.h>
 #include <direct.h>
+#define getcwd _getcwd  // fix MSVC warning
 #else
 #include <unistd.h>
 #endif   /* _MSC_VER */


### PR DESCRIPTION
fixes #398  (warning: 'getcwd' is deprecated: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _getcwd. See online help for details)