### PR TITLE
Fix callSystemDebug on Mac OS X.

### DIFF
--- a/src/utils2.c
+++ b/src/utils2.c
@@ -2658,17 +2658,17 @@ l_int32  ret;
 
 #if defined(__APPLE__)  /* iOS 11 does not support system() */
 
-  #if !defined(TARGET_OS_IPHONE) && !defined(OS_IOS)  /* macOS */
+  #if TARGET_OS_OSX /* Mac OS X */
     ret = system(cmd);
-  #else
+  #elif TARGET_OS_IPHONE || defined(OS_IOS)  /* iOS */
     L_ERROR("iOS 11 does not support system()\n", procName);
-  #endif  /* !TARGET_OS_IPHONE ... */
+  #endif  /* TARGET_OS_OSX */
 
-#else /* ! OS_IOS */
+#else /* ! __APPLE__ */
 
    ret = system(cmd);
 
-#endif /* OS_IOS */
+#endif /* __APPLE__ */
 }
 
 


### PR DESCRIPTION
I was not able to view image results of the examples in `./prog` that used `callSystemDebug`.

`TargetConditional.h` (included if `__APPLE__`) contains the following:
```cpp
defined(__MACOS_CLASSIC__) )
    #define TARGET_OS_MAC               1
    #define TARGET_OS_WIN32             0
    #define TARGET_OS_UNIX              0

    #if !DYNAMIC_TARGETS_ENABLED
        #define TARGET_OS_OSX               1
        #define TARGET_OS_IPHONE            0
        #define TARGET_OS_IOS               0
        #define TARGET_OS_WATCH             0
        
        #define TARGET_OS_TV                0
        #define TARGET_OS_SIMULATOR         0
        #define TARGET_OS_EMBEDDED          0 
        #define TARGET_OS_RTKIT             0 
    #endif
    
    #define TARGET_IPHONE_SIMULATOR     TARGET_OS_SIMULATOR /* deprecated */
    #define TARGET_OS_NANO              TARGET_OS_WATCH /* deprecated */ 
```

Above means that all `TARGET` macros are defined, their values need to be checked instead. I've adjusted that and now can run the `callSystemDebug` function on Mac OS X. I have left the previous behavior (with `OS_IOS`) unchanged.

What remains a mystery is `OS_IOS` macro. I do not see it defined anywhere in the leptonica project, so it stays undefined unless someone defines it through their build system. It might be better to use `TARGET_OS_IPHONE|TARGET_OS_IOS` or some other defined macro that joins `_TV,_SIMULATOR,_WATCH` or add `OS_IOS` in the build explicitly so that it can be set if building for iOS.

