### PR TITLE
fixing https://github.com/rmtheis/tess-two/issues/159

### DIFF
--- a/src/pixabasic.c
+++ b/src/pixabasic.c
@@ -1315,6 +1315,7 @@ BOXA  *boxa;
 
     pixDestroy(&(pixa->pix[index]));
     pixa->pix[index] = pix;
+    pixChangeRefCount(pix, 1);
 
     if (box) {
         boxa = pixa->boxa;


### PR DESCRIPTION
The issue with the Java test is that **pixaReplacePix()** does not increase `pix->refcount`. Therefore, destroying both the **pix** and the **pixa** reaches `refcount == -1`, and results in a crash.