### PR TITLE
sel1: Fix fall through warnings

### DIFF
--- a/src/sel1.c
+++ b/src/sel1.c
@@ -1648,6 +1648,7 @@ char     ch;
                 case 'X':
                     norig++;
                     selSetOrigin(sel, y, x);
+                    /* fall through */
                 case 'x':
                     selSetElement(sel, y, x, SEL_HIT);
                     break;
@@ -1655,6 +1656,7 @@ char     ch;
                 case 'O':
                     norig++;
                     selSetOrigin(sel, y, x);
+                    /* fall through */
                 case 'o':
                     selSetElement(sel, y, x, SEL_MISS);
                     break;
@@ -1662,6 +1664,7 @@ char     ch;
                 case 'C':
                     norig++;
                     selSetOrigin(sel, y, x);
+                    /* fall through */
                 case ' ':
                     selSetElement(sel, y, x, SEL_DONT_CARE);
                     break;
@@ -1917,18 +1920,21 @@ SEL     *sel;
             {
                 case 'X':
                     selSetOrigin(sel, y, x);  /* set origin and hit */
+                    /* fall through */
                 case 'x':
                     selSetElement(sel, y, x, SEL_HIT);
                     break;
 
                 case 'O':
                     selSetOrigin(sel, y, x);  /* set origin and miss */
+                    /* fall through */
                 case 'o':
                     selSetElement(sel, y, x, SEL_MISS);
                     break;
 
                 case 'C':
                     selSetOrigin(sel, y, x);  /* set origin and don't-care */
+                    /* fall through */
                 case ' ':
                     selSetElement(sel, y, x, SEL_DONT_CARE);
                     break;


### PR DESCRIPTION
gcc warning:

    sel1.c:1650:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
    sel1.c:1657:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
    sel1.c:1664:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
    sel1.c:1919:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
    sel1.c:1925:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
    sel1.c:1931:21: warning: this statement may fall through [-Wimplicit-fallthrough=]

Signed-off-by: Stefan Weil <sw@weilnetz.de>