### PR TITLE
Fix checks which require gnuplot

### DIFF
--- a/prog/reg_wrapper.sh
+++ b/prog/reg_wrapper.sh
@@ -32,7 +32,7 @@ TEST_NAME="${TEST_NAME%_reg*}"
 
 case "${TEST_NAME}" in
     baseline|boxa[1234]|colormask|colorspace|dna|enhance|extrema|fpix1|italic|kernel|nearline|numa[12]|projection|rankbin|rankhisto|wordboxes)
-        GNUPLOT=$(type -P gnuplot || type -P wgnuplot)
+        GNUPLOT=$(which gnuplot || which wgnuplot)
 
         if [ -z "${GNUPLOT}" ] || ! "${GNUPLOT}" -e "set terminal png" 2>/dev/null ; then
             exec ${@%${TEST}} /bin/sh -c "exit 77"


### PR DESCRIPTION
Those checks were skipped since commit 1b3c9b64ee204b3f9371cea624c959b3177c9c1d
because the `sh` shell does not support `type -P`.

Signed-off-by: Stefan Weil <sw@weilnetz.de>