### PR TITLE
Fix parallel running of tests by using unique directories

### DIFF
--- a/prog/Makefile.am
+++ b/prog/Makefile.am
@@ -1,4 +1,4 @@
-AUTOMAKE_OPTIONS = serial-tests
+AUTOMAKE_OPTIONS = parallel-tests
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src
 LDADD = $(top_builddir)/src/liblept.la $(LIBM)
  

--- a/prog/pdfio1_reg.c
+++ b/prog/pdfio1_reg.c
@@ -75,39 +75,39 @@ L_REGPARAMS  *rp;
         return 1;
 
     l_pdfSetDateAndVersion(0);
-    lept_mkdir("lept/pdf");
+    lept_mkdir("lept/pdf1");
 
 #if 1
     /* ---------------  Single image tests  ------------------- */
     fprintf(stderr, "\n*** Writing single images as pdf files\n");
 
-    convertToPdf("weasel2.4c.png", L_FLATE_ENCODE, 0, "/tmp/lept/pdf/file00.pdf",
+    convertToPdf("weasel2.4c.png", L_FLATE_ENCODE, 0, "/tmp/lept/pdf1/file00.pdf",
                  0, 0, 72, "weasel2.4c.png", NULL, 0);
-    convertToPdf("test24.jpg", L_JPEG_ENCODE, 0, "/tmp/lept/pdf/file01.pdf",
+    convertToPdf("test24.jpg", L_JPEG_ENCODE, 0, "/tmp/lept/pdf1/file01.pdf",
                  0, 0, 72, "test24.jpg", NULL, 0);
-    convertToPdf("feyn.tif", L_G4_ENCODE, 0, "/tmp/lept/pdf/file02.pdf",
+    convertToPdf("feyn.tif", L_G4_ENCODE, 0, "/tmp/lept/pdf1/file02.pdf",
                  0, 0, 300, "feyn.tif", NULL, 0);
 
     pixs = pixRead("feyn.tif");
-    pixConvertToPdf(pixs, L_G4_ENCODE, 0, "/tmp/lept/pdf/file03.pdf", 0, 0, 300,
+    pixConvertToPdf(pixs, L_G4_ENCODE, 0, "/tmp/lept/pdf1/file03.pdf", 0, 0, 300,
                     "feyn.tif", NULL, 0);
     pixDestroy(&pixs);
 
     pixs = pixRead("test24.jpg");
-    pixConvertToPdf(pixs, L_JPEG_ENCODE, 5, "/tmp/lept/pdf/file04.pdf",
+    pixConvertToPdf(pixs, L_JPEG_ENCODE, 5, "/tmp/lept/pdf1/file04.pdf",
                     0, 0, 72, "test24.jpg", NULL, 0);
     pixDestroy(&pixs);
 
     pixs = pixRead("feyn.tif");
     pixt = pixScaleToGray2(pixs);
-    pixWrite("/tmp/lept/pdf/feyn8.png", pixt, IFF_PNG);
-    convertToPdf("/tmp/lept/pdf/feyn8.png", L_JPEG_ENCODE, 0,
-                 "/tmp/lept/pdf/file05.pdf", 0, 0, 150, "feyn8.png", NULL, 0);
+    pixWrite("/tmp/lept/pdf1/feyn8.png", pixt, IFF_PNG);
+    convertToPdf("/tmp/lept/pdf1/feyn8.png", L_JPEG_ENCODE, 0,
+                 "/tmp/lept/pdf1/file05.pdf", 0, 0, 150, "feyn8.png", NULL, 0);
     pixDestroy(&pixs);
     pixDestroy(&pixt);
 
     convertToPdf("weasel4.16g.png", L_FLATE_ENCODE, 0,
-                 "/tmp/lept/pdf/file06.pdf", 0, 0, 30,
+                 "/tmp/lept/pdf1/file06.pdf", 0, 0, 30,
                  "weasel4.16g.png", NULL, 0);
 
     pixs = pixRead("test24.jpg");
@@ -115,12 +115,12 @@ L_REGPARAMS  *rp;
     box = boxCreate(100, 100, 100, 100);
     pixc = pixClipRectangle(pixs, box, NULL);
     pixgc = pixClipRectangle(pixg, box, NULL);
-    pixWrite("/tmp/lept/pdf/pix32.jpg", pixc, IFF_JFIF_JPEG);
-    pixWrite("/tmp/lept/pdf/pix8.jpg", pixgc, IFF_JFIF_JPEG);
-    convertToPdf("/tmp/lept/pdf/pix32.jpg", L_FLATE_ENCODE, 0,
-                 "/tmp/lept/pdf/file07.pdf", 0, 0, 72, "pix32.jpg", NULL, 0);
-    convertToPdf("/tmp/lept/pdf/pix8.jpg", L_FLATE_ENCODE, 0,
-                 "/tmp/lept/pdf/file08.pdf", 0, 0, 72, "pix8.jpg", NULL, 0);
+    pixWrite("/tmp/lept/pdf1/pix32.jpg", pixc, IFF_JFIF_JPEG);
+    pixWrite("/tmp/lept/pdf1/pix8.jpg", pixgc, IFF_JFIF_JPEG);
+    convertToPdf("/tmp/lept/pdf1/pix32.jpg", L_FLATE_ENCODE, 0,
+                 "/tmp/lept/pdf1/file07.pdf", 0, 0, 72, "pix32.jpg", NULL, 0);
+    convertToPdf("/tmp/lept/pdf1/pix8.jpg", L_FLATE_ENCODE, 0,
+                 "/tmp/lept/pdf1/file08.pdf", 0, 0, 72, "pix8.jpg", NULL, 0);
     pixDestroy(&pixs);
     pixDestroy(&pixg);
     pixDestroy(&pixc);
@@ -145,7 +145,7 @@ L_REGPARAMS  *rp;
                             100 * i, 70, title, &lpd, seq);
         }
     }
-    pixConvertToPdf(pix1, L_G4_ENCODE, 0, "/tmp/lept/pdf/file09.pdf", 0, 0, 80,
+    pixConvertToPdf(pix1, L_G4_ENCODE, 0, "/tmp/lept/pdf1/file09.pdf", 0, 0, 80,
                     NULL, &lpd, L_LAST_IMAGE);
 
         /* Now, write the 1 bpp image over the weasels */
@@ -158,7 +158,7 @@ L_REGPARAMS  *rp;
                             100 * i, 70, title, &lpd, seq);
         }
     }
-    pixConvertToPdf(pix1, L_G4_ENCODE, 0, "/tmp/lept/pdf/file10.pdf", 0, 0, 80,
+    pixConvertToPdf(pix1, L_G4_ENCODE, 0, "/tmp/lept/pdf1/file10.pdf", 0, 0, 80,
                     NULL, &lpd, L_LAST_IMAGE);
     l_pdfSetG4ImageMask(1);
     pixDestroy(&pix1);
@@ -171,36 +171,36 @@ L_REGPARAMS  *rp;
 
     pix1 = pixRead("rabi.png");
     pix2 = pixScaleToGray2(pix1);
-    pixWrite("/tmp/lept/pdf/rabi8.jpg", pix2, IFF_JFIF_JPEG);
+    pixWrite("/tmp/lept/pdf1/rabi8.jpg", pix2, IFF_JFIF_JPEG);
     pix3 = pixThresholdTo4bpp(pix2, 16, 1);
-    pixWrite("/tmp/lept/pdf/rabi4.png", pix3, IFF_PNG);
+    pixWrite("/tmp/lept/pdf1/rabi4.png", pix3, IFF_PNG);
     pixDestroy(&pix1);
     pixDestroy(&pix2);
     pixDestroy(&pix3);
 
         /* 1 bpp input */
     convertToPdfSegmented("rabi.png", 300, L_G4_ENCODE, 128, NULL, 0, 0,
-                          NULL, "/tmp/lept/pdf/file11.pdf");
+                          NULL, "/tmp/lept/pdf1/file11.pdf");
     convertToPdfSegmented("rabi.png", 300, L_JPEG_ENCODE, 128, NULL, 0, 0,
-                          NULL, "/tmp/lept/pdf/file12.pdf");
+                          NULL, "/tmp/lept/pdf1/file12.pdf");
     convertToPdfSegmented("rabi.png", 300, L_FLATE_ENCODE, 128, NULL, 0, 0,
-                          NULL, "/tmp/lept/pdf/file13.pdf");
+                          NULL, "/tmp/lept/pdf1/file13.pdf");
 
         /* 8 bpp input, no cmap */
-    convertToPdfSegmented("/tmp/lept/pdf/rabi8.jpg", 150, L_G4_ENCODE, 128,
-                          NULL, 0, 0, NULL, "/tmp/lept/pdf/file14.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi8.jpg", 150, L_JPEG_ENCODE, 128,
-                          NULL, 0, 0, NULL, "/tmp/lept/pdf/file15.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi8.jpg", 150, L_FLATE_ENCODE, 128,
-                          NULL, 0, 0, NULL, "/tmp/lept/pdf/file16.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf1/rabi8.jpg", 150, L_G4_ENCODE, 128,
+                          NULL, 0, 0, NULL, "/tmp/lept/pdf1/file14.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf1/rabi8.jpg", 150, L_JPEG_ENCODE, 128,
+                          NULL, 0, 0, NULL, "/tmp/lept/pdf1/file15.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf1/rabi8.jpg", 150, L_FLATE_ENCODE, 128,
+                          NULL, 0, 0, NULL, "/tmp/lept/pdf1/file16.pdf");
 
         /* 4 bpp input, cmap */
-    convertToPdfSegmented("/tmp/lept/pdf/rabi4.png", 150, L_G4_ENCODE, 128,
-                          NULL, 0, 0, NULL, "/tmp/lept/pdf/file17.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi4.png", 150, L_JPEG_ENCODE, 128,
-                          NULL, 0, 0, NULL, "/tmp/lept/pdf/file18.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi4.png", 150, L_FLATE_ENCODE, 128,
-                          NULL, 0, 0, NULL, "/tmp/lept/pdf/file19.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf1/rabi4.png", 150, L_G4_ENCODE, 128,
+                          NULL, 0, 0, NULL, "/tmp/lept/pdf1/file17.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf1/rabi4.png", 150, L_JPEG_ENCODE, 128,
+                          NULL, 0, 0, NULL, "/tmp/lept/pdf1/file18.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf1/rabi4.png", 150, L_FLATE_ENCODE, 128,
+                          NULL, 0, 0, NULL, "/tmp/lept/pdf1/file19.pdf");
 
 #endif
 
@@ -208,27 +208,27 @@ L_REGPARAMS  *rp;
     /* ----------  Generating from 1 bpp images (high-level) -------------- */
     fprintf(stderr, "\n*** Writing 1 bpp images as pdf files (high-level)\n");
     pix1 = pixRead("feyn-fract.tif");
-    pixWrite("/tmp/lept/pdf/feyn-nocmap.png", pix1, IFF_PNG);
+    pixWrite("/tmp/lept/pdf1/feyn-nocmap.png", pix1, IFF_PNG);
     pix2 = pixCopy(NULL, pix1);
     cmap = pixcmapCreate(1);
     pixcmapAddColor(cmap, 0, 0, 0);  /* with cmap: black bg, white letters */
     pixcmapAddColor(cmap, 255, 255, 255);
     pixSetColormap(pix2, cmap);
-    pixWrite("/tmp/lept/pdf/feyn-cmap1.png", pix2, IFF_PNG);
+    pixWrite("/tmp/lept/pdf1/feyn-cmap1.png", pix2, IFF_PNG);
     cmap = pixcmapCreate(1);
     pixcmapAddColor(cmap, 200, 0, 0);  /* with cmap: red bg, white letters */
     pixcmapAddColor(cmap, 255, 255, 255);
     pixSetColormap(pix1, cmap);
-    pixWrite("/tmp/lept/pdf/feyn-cmap2.png", pix1, IFF_PNG);
+    pixWrite("/tmp/lept/pdf1/feyn-cmap2.png", pix1, IFF_PNG);
 
-    convertToPdf("/tmp/lept/pdf/feyn-nocmap.png", L_FLATE_ENCODE, 0,
-                 "/tmp/lept/pdf/file20.pdf",
+    convertToPdf("/tmp/lept/pdf1/feyn-nocmap.png", L_FLATE_ENCODE, 0,
+                 "/tmp/lept/pdf1/file20.pdf",
                  0, 0, 0, NULL, NULL, 0);
-    convertToPdf("/tmp/lept/pdf/feyn-cmap1.png", L_FLATE_ENCODE, 0,
-                 "/tmp/lept/pdf/file21.pdf",
+    convertToPdf("/tmp/lept/pdf1/feyn-cmap1.png", L_FLATE_ENCODE, 0,
+                 "/tmp/lept/pdf1/file21.pdf",
                  0, 0, 0, NULL, NULL, 0);
-    convertToPdf("/tmp/lept/pdf/feyn-cmap2.png", L_FLATE_ENCODE, 0,
-                 "/tmp/lept/pdf/file22.pdf",
+    convertToPdf("/tmp/lept/pdf1/feyn-cmap2.png", L_FLATE_ENCODE, 0,
+                 "/tmp/lept/pdf1/file22.pdf",
                  0, 0, 0, NULL, NULL, 0);
     pixDestroy(&pix1);
     pixDestroy(&pix2);
@@ -245,23 +245,23 @@ L_REGPARAMS  *rp;
     pixcmapAddColor(cmap, 255, 255, 255);  /* white = 0 */
     pixcmapAddColor(cmap, 0, 0, 0);  /* black = 1 */
     pixSetColormap(pix2, cmap);  /* replace with a b/w colormap */
-    pixWrite("/tmp/lept/pdf/cat-and-mouse-cmap1.png", pix2, IFF_PNG);
+    pixWrite("/tmp/lept/pdf1/cat-and-mouse-cmap1.png", pix2, IFF_PNG);
 
         /* Generate a pdf from this pix. The pdf has the colormap */
     pixGenerateCIData(pix2, L_FLATE_ENCODE, 0, 0, &cid);
     fprintf(stderr, "  Should have 2 colors: %d\n", cid->ncolors);
     cidConvertToPdfData(cid, "with colormap", &data8, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file23.pdf", "w", data8, nbytes);
+    l_binaryWrite("/tmp/lept/pdf1/file23.pdf", "w", data8, nbytes);
     lept_free(data8);
 
         /* Generate a pdf from the colormap file:
          *   l_generateCIDataForPdf() calls l_generateFlateDataPdf()
          *   which calls pixRead(), removing the cmap  */
-    l_generateCIDataForPdf("/tmp/lept/pdf/cat-and-mouse-cmap1.png",
+    l_generateCIDataForPdf("/tmp/lept/pdf1/cat-and-mouse-cmap1.png",
                            NULL, 75, &cid);
     fprintf(stderr, "  Should have 0 colors: %d\n", cid->ncolors);
     cidConvertToPdfData(cid, "no colormap", &data8, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file24.pdf", "w", data8, nbytes);
+    l_binaryWrite("/tmp/lept/pdf1/file24.pdf", "w", data8, nbytes);
     lept_free(data8);
 
         /* Use an arbitrary colormap */
@@ -269,52 +269,52 @@ L_REGPARAMS  *rp;
     pixcmapAddColor(cmap, 254, 240, 185);  // yellow
     pixcmapAddColor(cmap, 50, 50, 130);   // blue
     pixSetColormap(pix2, cmap);
-    pixWrite("/tmp/lept/pdf/cat-and-mouse-cmap2.png", pix2, IFF_PNG);
+    pixWrite("/tmp/lept/pdf1/cat-and-mouse-cmap2.png", pix2, IFF_PNG);
 
        /* Generate a pdf from this pix. The pdf has the colormap. */
     pixGenerateCIData(pix2, L_FLATE_ENCODE, 0, 0, &cid);
     fprintf(stderr, "  Should have 2 colors: %d\n", cid->ncolors);
     cidConvertToPdfData(cid, "with colormap", &data8, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file25.pdf", "w", data8, nbytes);
+    l_binaryWrite("/tmp/lept/pdf1/file25.pdf", "w", data8, nbytes);
     lept_free(data8);
 
         /* Generate a pdf from the cmap file.  No cmap in the pdf. */
-    l_generateCIDataForPdf("/tmp/lept/pdf/cat-and-mouse-cmap2.png",
+    l_generateCIDataForPdf("/tmp/lept/pdf1/cat-and-mouse-cmap2.png",
                            NULL, 75, &cid);
     fprintf(stderr, "  Should have 0 colors: %d\n", cid->ncolors);
     cidConvertToPdfData(cid, "no colormap", &data8, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file26.pdf", "w", data8, nbytes);
+    l_binaryWrite("/tmp/lept/pdf1/file26.pdf", "w", data8, nbytes);
     lept_free(data8);
     pixDestroy(&pix1);
     pixDestroy(&pix2);
 #endif
 
-    regTestCheckFile(rp, "/tmp/lept/pdf/file00.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file01.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file02.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file03.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file04.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file05.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file06.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file07.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file08.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file09.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file10.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file11.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file12.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file13.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file14.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file15.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file16.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file17.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file18.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file19.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file20.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file21.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file22.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file23.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file24.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file25.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file26.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file00.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file01.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file02.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file03.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file04.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file05.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file06.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file07.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file08.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file09.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file10.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file11.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file12.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file13.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file14.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file15.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file16.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file17.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file18.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file19.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file20.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file21.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file22.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file23.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file24.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file25.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf1/file26.pdf");
     return regTestCleanup(rp);
 }

--- a/prog/pdfio2_reg.c
+++ b/prog/pdfio2_reg.c
@@ -68,7 +68,7 @@ L_REGPARAMS  *rp;
         return 1;
 
     l_pdfSetDateAndVersion(0);
-    lept_mkdir("lept/pdf");
+    lept_mkdir("lept/pdf2");
 
     /* ---------- pdf convert segmented with image regions ---------- */
     fprintf(stderr, "\n*** Writing segmented images with image regions\n");
@@ -78,6 +78,12 @@ L_REGPARAMS  *rp;
          * small bogus regions at the top, but we'll keep them for
          * the demonstration. */
     pix1 = pixRead("rabi.png");
+    pix2 = pixScaleToGray2(pix1);
+    pixWrite("/tmp/lept/pdf2/rabi8.jpg", pix2, IFF_JFIF_JPEG);
+    pix3 = pixThresholdTo4bpp(pix2, 16, 1);
+    pixWrite("/tmp/lept/pdf2/rabi4.png", pix3, IFF_PNG);
+    pixDestroy(&pix2);
+    pixDestroy(&pix3);
     pixSetResolution(pix1, 300, 300);
     pixGetDimensions(pix1, &w, &h, NULL);
     pix2 = pixGenerateHalftoneMask(pix1, NULL, NULL, NULL);
@@ -90,41 +96,41 @@ L_REGPARAMS  *rp;
 
         /* 1 bpp input */
     convertToPdfSegmented("rabi.png", 300, L_G4_ENCODE, 128, boxa1,
-                          0, 0.25, NULL, "/tmp/lept/pdf/file00.pdf");
+                          0, 0.25, NULL, "/tmp/lept/pdf2/file00.pdf");
     convertToPdfSegmented("rabi.png", 300, L_JPEG_ENCODE, 128, boxa1,
-                          0, 0.25, NULL, "/tmp/lept/pdf/file01.pdf");
+                          0, 0.25, NULL, "/tmp/lept/pdf2/file01.pdf");
     convertToPdfSegmented("rabi.png", 300, L_FLATE_ENCODE, 128, boxa1,
-                          0, 0.25, NULL, "/tmp/lept/pdf/file02.pdf");
+                          0, 0.25, NULL, "/tmp/lept/pdf2/file02.pdf");
 
         /* 8 bpp input, no cmap */
-    convertToPdfSegmented("/tmp/lept/pdf/rabi8.jpg", 150, L_G4_ENCODE, 128,
-                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file03.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi8.jpg", 150, L_JPEG_ENCODE, 128,
-                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file04.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi8.jpg", 150, L_FLATE_ENCODE, 128,
-                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file05.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/rabi8.jpg", 150, L_G4_ENCODE, 128,
+                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file03.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/rabi8.jpg", 150, L_JPEG_ENCODE, 128,
+                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file04.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/rabi8.jpg", 150, L_FLATE_ENCODE, 128,
+                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file05.pdf");
 
         /* 4 bpp input, cmap */
-    convertToPdfSegmented("/tmp/lept/pdf/rabi4.png", 150, L_G4_ENCODE, 128,
-                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file06.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi4.png", 150, L_JPEG_ENCODE, 128,
-                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file07.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/rabi4.png", 150, L_FLATE_ENCODE, 128,
-                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file08.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/rabi4.png", 150, L_G4_ENCODE, 128,
+                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file06.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/rabi4.png", 150, L_JPEG_ENCODE, 128,
+                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file07.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/rabi4.png", 150, L_FLATE_ENCODE, 128,
+                          boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file08.pdf");
 
         /* 4 bpp input, cmap, data output */
     data = NULL;
-    convertToPdfDataSegmented("/tmp/lept/pdf/rabi4.png", 150, L_G4_ENCODE,
+    convertToPdfDataSegmented("/tmp/lept/pdf2/rabi4.png", 150, L_G4_ENCODE,
                               128, boxa2, 0, 0.5, NULL, &data, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file09.pdf", "w", data, nbytes);
+    l_binaryWrite("/tmp/lept/pdf2/file09.pdf", "w", data, nbytes);
     lept_free(data);
-    convertToPdfDataSegmented("/tmp/lept/pdf/rabi4.png", 150, L_JPEG_ENCODE,
+    convertToPdfDataSegmented("/tmp/lept/pdf2/rabi4.png", 150, L_JPEG_ENCODE,
                               128, boxa2, 0, 0.5, NULL, &data, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file10.pdf", "w", data, nbytes);
+    l_binaryWrite("/tmp/lept/pdf2/file10.pdf", "w", data, nbytes);
     lept_free(data);
-    convertToPdfDataSegmented("/tmp/lept/pdf/rabi4.png", 150, L_FLATE_ENCODE,
+    convertToPdfDataSegmented("/tmp/lept/pdf2/rabi4.png", 150, L_FLATE_ENCODE,
                               128, boxa2, 0, 0.5, NULL, &data, &nbytes);
-    l_binaryWrite("/tmp/lept/pdf/file11.pdf", "w", data, nbytes);
+    l_binaryWrite("/tmp/lept/pdf2/file11.pdf", "w", data, nbytes);
     lept_free(data);
     fprintf(stderr, "Segmented images time: %7.3f\n", stopTimer());
 
@@ -138,17 +144,17 @@ L_REGPARAMS  *rp;
 
     pix1 = pixRead("candelabrum.011.jpg");
     pix2 = pixScale(pix1, 3.0, 3.0);
-    pixWrite("/tmp/lept/pdf/candelabrum3.jpg", pix2, IFF_JFIF_JPEG);
-    GetImageMask(pix2, 200, &boxa1, rp, "/tmp/lept/pdf/seg1.jpg");
-    convertToPdfSegmented("/tmp/lept/pdf/candelabrum3.jpg", 200, L_G4_ENCODE,
+    pixWrite("/tmp/lept/pdf2/candelabrum3.jpg", pix2, IFF_JFIF_JPEG);
+    GetImageMask(pix2, 200, &boxa1, rp, "/tmp/lept/pdf2/seg1.jpg");
+    convertToPdfSegmented("/tmp/lept/pdf2/candelabrum3.jpg", 200, L_G4_ENCODE,
                           100, boxa1, 0, 0.25, NULL,
-                          "/tmp/lept/pdf/file12.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/candelabrum3.jpg", 200, L_JPEG_ENCODE,
+                          "/tmp/lept/pdf2/file12.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/candelabrum3.jpg", 200, L_JPEG_ENCODE,
                           100, boxa1, 0, 0.25, NULL,
-                          "/tmp/lept/pdf/file13.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/candelabrum3.jpg", 200, L_FLATE_ENCODE,
+                          "/tmp/lept/pdf2/file13.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/candelabrum3.jpg", 200, L_FLATE_ENCODE,
                           100, boxa1, 0, 0.25, NULL,
-                          "/tmp/lept/pdf/file14.pdf");
+                          "/tmp/lept/pdf2/file14.pdf");
 
     pixDestroy(&pix1);
     pixDestroy(&pix2);
@@ -156,25 +162,25 @@ L_REGPARAMS  *rp;
 
     pix1 = pixRead("lion-page.00016.jpg");
     pix2 = pixScale(pix1, 3.0, 3.0);
-    pixWrite("/tmp/lept/pdf/lion16.jpg", pix2, IFF_JFIF_JPEG);
+    pixWrite("/tmp/lept/pdf2/lion16.jpg", pix2, IFF_JFIF_JPEG);
     pix3 = pixRead("lion-mask.00016.tif");
     boxa1 = pixConnComp(pix3, NULL, 8);
     boxa2 = boxaTransform(boxa1, 0, 0, 3.0, 3.0);
-    convertToPdfSegmented("/tmp/lept/pdf/lion16.jpg", 200, L_G4_ENCODE,
-                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file15.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/lion16.jpg", 200, L_JPEG_ENCODE,
-                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file16.pdf");
-    convertToPdfSegmented("/tmp/lept/pdf/lion16.jpg", 200, L_FLATE_ENCODE,
-                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file17.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/lion16.jpg", 200, L_G4_ENCODE,
+                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file15.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/lion16.jpg", 200, L_JPEG_ENCODE,
+                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file16.pdf");
+    convertToPdfSegmented("/tmp/lept/pdf2/lion16.jpg", 200, L_FLATE_ENCODE,
+                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file17.pdf");
 
         /* Quantize the non-image part and flate encode.
          * This is useful because it results in a smaller file than
          * when you flate-encode the un-quantized non-image regions. */
     pix4 = pixScale(pix3, 3.0, 3.0);  /* higher res mask, for combining */
     pix5 = QuantizeNonImageRegion(pix2, pix4, 12);
-    pixWrite("/tmp/lept/pdf/lion16-quant.png", pix5, IFF_PNG);
-    convertToPdfSegmented("/tmp/lept/pdf/lion16-quant.png", 200, L_FLATE_ENCODE,
-                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf/file18.pdf");
+    pixWrite("/tmp/lept/pdf2/lion16-quant.png", pix5, IFF_PNG);
+    convertToPdfSegmented("/tmp/lept/pdf2/lion16-quant.png", 200, L_FLATE_ENCODE,
+                          190, boxa2, 0, 0.5, NULL, "/tmp/lept/pdf2/file18.pdf");
     fprintf(stderr, "Color segmented images time: %7.3f\n", stopTimer());
 
     pixDestroy(&pix1);
@@ -210,8 +216,8 @@ L_REGPARAMS  *rp;
 
     startTimer();
     convertFilesToPdf("/tmp/lept/image", "file", 100, 0.8, 0, 75, "4 file test",
-                      "/tmp/lept/pdf/file19.pdf");
-    fprintf(stderr, "4-page pdf generated: /tmp/lept/pdf/file19.pdf\n"
+                      "/tmp/lept/pdf2/file19.pdf");
+    fprintf(stderr, "4-page pdf generated: /tmp/lept/pdf2/file19.pdf\n"
                     "Multi-page gen time: %7.3f\n", stopTimer());
     pixDestroy(&pix1);
     pixDestroy(&pix2);
@@ -221,26 +227,26 @@ L_REGPARAMS  *rp;
     pixDestroy(&pix6);
 #endif
 
-    regTestCheckFile(rp, "/tmp/lept/pdf/file00.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file01.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file02.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file03.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file04.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file05.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file06.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file07.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file08.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file09.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file10.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file11.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file12.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file13.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file14.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file15.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file16.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file17.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file18.pdf");
-    regTestCheckFile(rp, "/tmp/lept/pdf/file19.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file00.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file01.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file02.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file03.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file04.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file05.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file06.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file07.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file08.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file09.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file10.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file11.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file12.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file13.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file14.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file15.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file16.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file17.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file18.pdf");
+    regTestCheckFile(rp, "/tmp/lept/pdf2/file19.pdf");
 
 #if 1
     /* ------------------ Test multipage pdf generation ----------------- */
@@ -248,9 +254,9 @@ L_REGPARAMS  *rp;
 
         /* Generate a multi-page pdf from all these files */
     startTimer();
-    concatenatePdf("/tmp/lept/pdf", "file", "/tmp/lept/pdf/cat_lept.pdf");
+    concatenatePdf("/tmp/lept/pdf2", "file", "/tmp/lept/pdf2/cat_lept.pdf");
     fprintf(stderr,
-            "All files have been concatenated: /tmp/lept/pdf/cat_lept.pdf\n"
+            "All files have been concatenated: /tmp/lept/pdf2/cat_lept.pdf\n"
                     "Concatenation time: %7.3f\n", stopTimer());
 #endif
 
@@ -262,7 +268,7 @@ L_REGPARAMS  *rp;
     lept_mkdir("lept/good");
     lept_cp("testfile1.pdf", "lept/good", NULL, NULL);
     lept_cp("testfile2.pdf", "lept/good", NULL, NULL);
-    concatenatePdf("/tmp/lept/good", "file", "/tmp/lept/pdf/good.pdf");
+    concatenatePdf("/tmp/lept/good", "file", "/tmp/lept/pdf2/good.pdf");
 
         /* Make a bad version with the pdf id removed, so that it is not
          * recognized as a pdf */
@@ -287,9 +293,9 @@ L_REGPARAMS  *rp;
     fprintf(stderr, "******************************************************\n");
     fprintf(stderr, "* The next 3 error messages are intentional          *\n");
     lept_cp("testfile1.pdf", "lept/bad", NULL, NULL);
-    concatenatePdf("/tmp/lept/bad", "file", "/tmp/lept/pdf/bad.pdf");
+    concatenatePdf("/tmp/lept/bad", "file", "/tmp/lept/pdf2/bad.pdf");
     fprintf(stderr, "******************************************************\n");
-    filesAreIdentical("/tmp/lept/pdf/good.pdf", "/tmp/lept/pdf/bad.pdf", &same);
+    filesAreIdentical("/tmp/lept/pdf2/good.pdf", "/tmp/lept/pdf2/bad.pdf", &same);
     if (same)
         fprintf(stderr, "Fixed: files are the same\n"
                         "Attempt succeeded\n");
@@ -305,8 +311,8 @@ L_REGPARAMS  *rp;
     l_int32  ret;
 
     fprintf(stderr, "\n*** pdftk writes multipage pdfs from images\n");
-    tempfile1 = genPathname("/tmp/lept/pdf", "file*.pdf");
-    tempfile2 = genPathname("/tmp/lept/pdf", "cat_pdftk.pdf");
+    tempfile1 = genPathname("/tmp/lept/pdf2", "file*.pdf");
+    tempfile2 = genPathname("/tmp/lept/pdf2", "cat_pdftk.pdf");
     snprintf(buffer, sizeof(buffer), "pdftk %s output %s",
              tempfile1, tempfile2);
     ret = system(buffer);  /* pdftk */

--- a/prog/webpanimio_reg.c
+++ b/prog/webpanimio_reg.c
@@ -75,8 +75,8 @@ L_REGPARAMS  *rp;
     return 0;
 #endif  /* abort */
 
-    lept_rmdir("lept/webp");
-    lept_mkdir("lept/webp");
+    lept_rmdir("lept/webpanim");
+    lept_mkdir("lept/webpanim");
 
     niters = 5;
     duration = 250;   /* ms */
@@ -85,9 +85,9 @@ L_REGPARAMS  *rp;
     pixa = pixaCreate(6);
     pixaAddPix(pixa, pix1, L_COPY);
     pixaAddPix(pixa, pix2, L_COPY);
-    pixaWriteWebPAnim("/tmp/lept/webp/margeanim.webp", pixa, niters,
+    pixaWriteWebPAnim("/tmp/lept/webpanim/margeanim.webp", pixa, niters,
                       duration, 80, 0);
-    regTestCheckFile(rp, "/tmp/lept/webp/margeanim.webp");
+    regTestCheckFile(rp, "/tmp/lept/webpanim/margeanim.webp");
     pixaDestroy(&pixa);
     pixDestroy(&pix1);
     pixDestroy(&pix2);


### PR DESCRIPTION
Following #472, I did find a way to make some tests depend on others but I then found that the only reason they break in parallel is because some tests write to the same directories for seemingly no reason. `pdfio2_reg` also depends on a couple of files written by `pdfio1_reg` but it's only a few small extra lines to make it also generate the same files. All the other tests are independent so it seems silly to have this one exception.