### PR TITLE
Move array lengths to #defines.

### DIFF
--- a/src/classapp.c
+++ b/src/classapp.c
@@ -56,7 +56,7 @@
 #include <string.h>
 #include "allheaders.h"
 
-static const l_int32 L_BUF_SIZE = 512;        /*!< size of filename buffer    */
+enum { L_BUF_SIZE = 512 };                    /*!< size of filename buffer    */
 static const l_int32 JB_WORDS_MIN_WIDTH = 5;  /*!< min. word width in pixels  */
 static const l_int32 JB_WORDS_MIN_HEIGHT = 3; /*!< min. word height in pixels */
 

--- a/src/fhmtauto.c
+++ b/src/fhmtauto.c
@@ -103,7 +103,7 @@
 
 #define   PROTOARGS   "(l_uint32 *, l_int32, l_int32, l_int32, l_uint32 *, l_int32);"
 
-static const l_int32  L_BUF_SIZE = 512;
+enum { L_BUF_SIZE = 512 };
 
 static char * makeBarrelshiftString(l_int32 delx, l_int32 dely, l_int32 type);
 static SARRAY * sarrayMakeInnerLoopDWACode(SEL *sel, l_int32 nhits, l_int32 nmisses);

--- a/src/fmorphauto.c
+++ b/src/fmorphauto.c
@@ -107,7 +107,7 @@
 
 #define   PROTOARGS   "(l_uint32 *, l_int32, l_int32, l_int32, l_uint32 *, l_int32);"
 
-static const l_int32  L_BUF_SIZE = 512;
+enum { L_BUF_SIZE = 512 };
 
 static char * makeBarrelshiftString(l_int32 delx, l_int32 dely);
 static SARRAY * sarrayMakeInnerLoopDWACode(SEL *sel, l_int32 index);

--- a/src/gplot.c
+++ b/src/gplot.c
@@ -147,7 +147,7 @@
 #include <string.h>
 #include "allheaders.h"
 
-static const l_int32  Bufsize = 512;  /* hardcoded below in fscanf */
+enum { Bufsize = 512 };  /* hardcoded below in fscanf */
 
 const char  *gplotstylenames[] = {"with lines",
                                   "with points",

--- a/src/jbclass.c
+++ b/src/jbclass.c
@@ -210,7 +210,7 @@
 #include <math.h>
 #include "allheaders.h"
 
-static const l_int32  L_BUF_SIZE = 512;
+enum { L_BUF_SIZE = 512 };
 
     /* For jbClassifyRankHaus(): size of border added around
      * pix of each c.c., to allow further processing.  This

--- a/src/psio2.c
+++ b/src/psio2.c
@@ -107,7 +107,7 @@
     /* Set default for writing bounding box hint */
 static l_int32  var_PS_WRITE_BOUNDING_BOX = 1;
 
-static const l_int32  Bufsize         = 512;
+enum { Bufsize         = 512 };
 static const l_int32  DefaultInputRes = 300;  /* typical scan res, ppi */
 static const l_int32  MinRes          = 5;
 static const l_int32  MaxRes          = 3000;

--- a/src/sel2.c
+++ b/src/sel2.c
@@ -68,7 +68,7 @@
 #include <math.h>
 #include "allheaders.h"
 
-static const l_int32  L_BUF_SIZE = 512;
+enum { L_BUF_SIZE = 512 };
 
     /* Linear brick sel sizes, including all those that are required
      * for decomposable sels up to size 63. */

--- a/src/writefile.c
+++ b/src/writefile.c
@@ -104,7 +104,7 @@ static l_int32  var_DISPLAY_PROG = L_DISPLAY_WITH_OPEN;  /* default */
 static l_int32  var_DISPLAY_PROG = L_DISPLAY_WITH_XZGV;  /* default */
 #endif  /* _WIN32 */
 
-static const l_int32  Bufsize = 512;
+enum { Bufsize = 512 };
 static const l_int32  MaxDisplayWidth = 1000;
 static const l_int32  MaxDisplayHeight = 800;
 static const l_int32  MaxSizeForPng = 200;


### PR DESCRIPTION
Using "static const int" for array lengths is a C feature too
new for Visual Studio's C compiler. Move to using enums instead
as this compiles everywhere and has no functional difference.