### PR TITLE
Added script to build corpora of fuzzers

### DIFF
--- a/prog/fuzzing/build_corpora.sh
+++ b/prog/fuzzing/build_corpora.sh
@@ -1,0 +1,4 @@
+cp $SRC/leptonica/prog/fuzzing/general_corpus.zip $OUT/pix_rotate_shear_fuzzer_seed_corpus.zip
+cp $SRC/leptonica/prog/fuzzing/general_corpus.zip $OUT/enhance_fuzzer_seed_corpus.zip
+
+cp $SRC/leptonica/prog/fuzzing/pixa_recog_fuzzer_seed_corpus.zip $OUT/


### PR DESCRIPTION
I am adding this script so that managing the corpora is done on Leptonicas own repository.

The file will be executed on line 150 in the build script (https://github.com/google/oss-fuzz/blob/master/projects/leptonica/build.sh), and the commands currently at line 150 will be removed from oss-fuzz's repository. 

It gives the maintainers of Leptonica more freedom to update the corpora by not having to wait for the oss-fuzz team to merge the updates in.

I will update the build script on oss-fuzz and rewrite the compilation of the fuzzers so that part doesn't have to be updated whenever a new fuzzer is added. This should remove all need to make PR's to oss-fuzz when a new fuzzer is added, modified or removed.