### PR TITLE
Added build script from oss-fuzz

### DIFF
--- a/prog/fuzzing/oss-fuzz-build.sh
+++ b/prog/fuzzing/oss-fuzz-build.sh
@@ -10,14 +10,6 @@ pushd $SRC/zstd
 make -j$(nproc) install PREFIX="$WORK"
 popd
 
-# libjbig
-pushd "$SRC/jbigkit"
-make clean
-make -j$(nproc) lib
-cp "$SRC"/jbigkit/libjbig/*.a "$WORK/lib/"
-cp "$SRC"/jbigkit/libjbig/*.h "$WORK/include/"
-popd
-
 # libjpeg-turbo
 pushd $SRC/libjpeg-turbo
 cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC:bool=on

--- a/prog/fuzzing/oss-fuzz-build.sh
+++ b/prog/fuzzing/oss-fuzz-build.sh
@@ -1,0 +1,110 @@
+# libz
+pushd $SRC/zlib
+./configure --static --prefix="$WORK"
+make -j$(nproc) all
+make install
+popd
+
+# libzstd
+pushd $SRC/zstd
+make -j$(nproc) install PREFIX="$WORK"
+popd
+
+# libjbig
+pushd "$SRC/jbigkit"
+make clean
+make -j$(nproc) lib
+cp "$SRC"/jbigkit/libjbig/*.a "$WORK/lib/"
+cp "$SRC"/jbigkit/libjbig/*.h "$WORK/include/"
+popd
+
+# libjpeg-turbo
+pushd $SRC/libjpeg-turbo
+cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC:bool=on
+make -j$(nproc)
+make install
+popd
+
+# libpng
+pushd $SRC/libpng
+cat scripts/pnglibconf.dfa | \
+  sed -e "s/option WARNING /option WARNING disabled/" \
+> scripts/pnglibconf.dfa.temp
+mv scripts/pnglibconf.dfa.temp scripts/pnglibconf.dfa
+autoreconf -f -i
+./configure \
+  --prefix="$WORK" \
+  --disable-shared \
+  --enable-static \
+  LDFLAGS="-L$WORK/lib" \
+  CPPFLAGS="-I$WORK/include"
+make -j$(nproc)
+make install
+popd
+
+# libwebp
+pushd $SRC/libwebp
+export WEBP_CFLAGS="$CFLAGS -DWEBP_MAX_IMAGE_SIZE=838860800" # 800MiB
+./autogen.sh
+./configure \
+  --enable-libwebpdemux \
+  --enable-libwebpmux \
+  --disable-shared \
+  --disable-jpeg \
+  --disable-tiff \
+  --disable-gif \
+  --disable-wic \
+  --disable-threading \
+  --prefix="$WORK" \
+  CFLAGS="$WEBP_CFLAGS"
+make clean
+make -j$(nproc)
+make install
+popd
+
+# libtiff
+pushd "$SRC/libtiff"
+cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DBUILD_SHARED_LIBS=off
+make clean
+make -j$(nproc)
+make install
+popd
+
+# leptonica
+export LEPTONICA_LIBS="$WORK/lib/libjbig.a $WORK/lib/libzstd.a $WORK/lib/libwebp.a $WORK/lib/libpng.a"
+./autogen.sh
+./configure \
+  --enable-static \
+  --disable-shared \
+  --with-libpng \
+  --with-zlib \
+  --with-jpeg \
+  --with-libwebp \
+  --with-libtiff \
+  --prefix="$WORK" \
+  LIBS="$LEPTONICA_LIBS" \
+  LDFLAGS="-L$WORK/lib" \
+  CPPFLAGS="-I$WORK/include"
+make -j$(nproc)
+make install
+
+for f in $SRC/leptonica/prog/fuzzing/*_fuzzer.cc; do
+  fuzzer=$(basename "$f" _fuzzer.cc)
+  $CXX $CXXFLAGS -std=c++11 -I"$WORK/include" \
+    $SRC/leptonica/prog/fuzzing/${fuzzer}_fuzzer.cc -o $OUT/${fuzzer}_fuzzer \
+    -Isrc/ \
+    "$WORK/lib/liblept.a" \
+    "$WORK/lib/libtiff.a" \
+    "$WORK/lib/libwebp.a" \
+    "$WORK/lib/libpng.a" \
+    "$WORK/lib/libjpeg.a" \
+    "$WORK/lib/libjbig.a" \
+    "$WORK/lib/libzstd.a" \
+    "$WORK/lib/libz.a" \
+    $LIB_FUZZING_ENGINE
+done
+
+cp $SRC/leptonica/prog/fuzzing/general_corpus.zip $OUT/pix_rotate_shear_fuzzer_seed_corpus.zip
+cp $SRC/leptonica/prog/fuzzing/general_corpus.zip $OUT/enhance_fuzzer_seed_corpus.zip
+
+cp $SRC/leptonica/prog/fuzzing/pixa_recog_fuzzer_seed_corpus.zip $OUT/


### PR DESCRIPTION
I am adding the build-script from oss-fuzz.

The script will be executed like with [LibreOffice ](https://github.com/google/oss-fuzz/blob/master/projects/libreoffice/build.sh)in build.sh in oss-fuzz.

Having the build script on Leptonicas own repository gives the maintainers of Leptonica more freedom to update the fuzzers and corpora by not having to wait for the oss-fuzz team to merge the updates in.

This PR adds 2 modifications to the build script compared to the current version on oss-fuzz:

1. The license header has been removed as it is not needed here.
2. The compilation of the fuzzers has been rewritten to prevent having to update the build script every time a fuzzer is added or removed. As long as each fuzzer is named *_fuzzer.cc and is placed in the `/prog/fuzzing` directory, it will be included.