### PR TITLE
Simplified pixa_recog_fuzzer

### DIFF
--- a/prog/fuzzing/oss-fuzz-build.sh
+++ b/prog/fuzzing/oss-fuzz-build.sh
@@ -10,6 +10,14 @@ pushd $SRC/zstd
 make -j$(nproc) install PREFIX="$WORK"
 popd
 
+# libjbig
+pushd "$SRC/jbigkit"
+make clean
+make -j$(nproc) lib
+cp "$SRC"/jbigkit/libjbig/*.a "$WORK/lib/"
+cp "$SRC"/jbigkit/libjbig/*.h "$WORK/include/"
+popd
+
 # libjpeg-turbo
 pushd $SRC/libjpeg-turbo
 cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC:bool=on

--- a/prog/fuzzing/pixa_recog_fuzzer.cc
+++ b/prog/fuzzing/pixa_recog_fuzzer.cc
@@ -9,52 +9,39 @@
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-        if(size<20) return 0;
+        if(size<10) return 0;
 
         char filename[256];
         sprintf(filename, "/tmp/libfuzzer.pa");
-
         FILE *fp = fopen(filename, "wb");
-        if (!fp)
-                return 0;
+        if (!fp) return 0;
         fwrite(data, size, 1, fp);
         fclose(fp);
 
-        char      *text;
-        l_int32    histo[10];
         PIXA      *pixa1, *pixa2, *pixa3, *pixa4;
-        L_RECOG   *recog1;
-        l_int32    i, n, ival;
-        PIX       *pix1;
+        L_RECOG   *recog1, *recog2;
+        PIX       *pix1, *pix2;
 
         pixa1 = pixaRead(filename);
         pixa2 = pixaCreate(0);
-        pixa3 = pixaCreate(0);
 
-        n = pixaGetCount(pixa1);
-        for (i = 0; i < 10; i++)
-                histo[i] = 0;
-        for (i = 0; i < n; i++) {
-                pix1 = pixaGetPix(pixa1, i, L_COPY);
-                text = pixGetText(pix1);
-                ival = text[0] - '0';
-                if (ival == 4 || (ival == 7 && histo[7] == 2) ||
-                        (ival == 9 && histo[9] == 2)) {
-                        pixaAddPix(pixa3, pix1, L_INSERT);
-                } else {
-                        pixaAddPix(pixa2, pix1, L_INSERT);
-                        histo[ival]++;
-                }
-        }
+        recog1 = recogCreateFromPixa(pixa1, 0, 40, 1, 128, 1);
+        
+        pixa2 = recogTrainFromBoot(recog1, pixa1, 0.75, 128, 1);
 
-        recog1 = recogCreateFromPixa(pixa2, 0, 40, 1, 128, 1);
-        pixa4 = recogTrainFromBoot(recog1, pixa3, 0.75, 128, 1);
+        pixa3 = pixaRemoveOutliers1(pixa1, 0.8, 4, 3, &pix1, &pix2);
+        recog2 = recogCreateFromPixa(pixa1, 4, 40, 1, 128, 1);
+
+        recogIdentifyMultiple(recog2, pix2, 0, 0, NULL, &pixa4, NULL, 1);
 
         recogDestroy(&recog1);
+        recogDestroy(&recog2);
         pixaDestroy(&pixa1);
         pixaDestroy(&pixa2);
         pixaDestroy(&pixa3);
         pixaDestroy(&pixa4);
+        pixDestroy(&pix1);
+        pixDestroy(&pix2);
         unlink(filename);
 
         return 0;

--- a/prog/fuzzing/pixa_recog_fuzzer.cc
+++ b/prog/fuzzing/pixa_recog_fuzzer.cc
@@ -1,7 +1,4 @@
-#include "string.h"
 #include "allheaders.h"
-#include <stdio.h>
-#include <stdlib.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -23,13 +20,13 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         PIX       *pix1, *pix2;
 
         pixa1 = pixaRead(filename);
-        pixa2 = pixaCreate(0);
 
         recog1 = recogCreateFromPixa(pixa1, 0, 40, 1, 128, 1);
         
         pixa2 = recogTrainFromBoot(recog1, pixa1, 0.75, 128, 1);
 
         pixa3 = pixaRemoveOutliers1(pixa1, 0.8, 4, 3, &pix1, &pix2);
+
         recog2 = recogCreateFromPixa(pixa1, 4, 40, 1, 128, 1);
 
         recogIdentifyMultiple(recog2, pix2, 0, 0, NULL, &pixa4, NULL, 1);
@@ -39,9 +36,6 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         pixaDestroy(&pixa1);
         pixaDestroy(&pixa2);
         pixaDestroy(&pixa3);
-        pixaDestroy(&pixa4);
-        pixDestroy(&pix1);
-        pixDestroy(&pix2);
         unlink(filename);
 
         return 0;


### PR DESCRIPTION
This PR removes the loop in the fuzzer that causes a null-dereferencer.