### PR TITLE
Added libjbig back to build script

### DIFF
--- a/prog/fuzzing/oss-fuzz-build.sh
+++ b/prog/fuzzing/oss-fuzz-build.sh
@@ -10,6 +10,14 @@ pushd $SRC/zstd
 make -j$(nproc) install PREFIX="$WORK"
 popd
 
+# libjbig
+pushd "$SRC/jbigkit"
+make clean
+make -j$(nproc) lib
+cp "$SRC"/jbigkit/libjbig/*.a "$WORK/lib/"
+cp "$SRC"/jbigkit/libjbig/*.h "$WORK/include/"
+popd
+
 # libjpeg-turbo
 pushd $SRC/libjpeg-turbo
 cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC:bool=on


### PR DESCRIPTION
This PR adds back libjbig to the build script of the fuzzers.

Travis reports that [the build fails using the newly added build file](https://travis-ci.org/github/google/oss-fuzz/builds/682136051). The build-error doesn't reproduce locally consistently, and it is odd that the compiler suddenly doesn't work halfway through the build script.

I request that we add back libjbig to the build script, as the log does show some errors related to the package.

Since the build file has not been updated yet, the fuzzers are still running fine on oss-fuzz's platform.