### PR TITLE
Fixed pixWriteStreamJp2k from creating an extra level.

### DIFF
--- a/src/jp2kio.c
+++ b/src/jp2kio.c
@@ -593,7 +593,7 @@ opj_image_t       *image = NULL;
     parameters.cp_fixed_alloc =  0;
     parameters.tcp_distoratio[0] = snr;
     parameters.tcp_numlayers = 1;
-    parameters.numresolution = nlevels + 1;
+    parameters.numresolution = nlevels;
 
         /* Create comment for codestream */
     if (parameters.cp_comment == NULL) {


### PR DESCRIPTION
Before this fix, calling pixWriteStreamJp2k with nlevels = 1 would create a file that could be loaded with reduction=1 and reduction=2.  If the file was created with nlevels = 2, then the file could be loaded with reduction=1, reduction=2, and reduction=4.

Calling pixWriteStreamJp2k with nlevels = 0 could trigger the default of 5, but then the you could load 6 images from the file at reduction 1, 2, 4, 8, 16, 32.

After this fix I'm getting the files with the expected number of reduced images.