### PR TITLE
Make reading of PNM files more robust

### DIFF
--- a/src/pnmio.c
+++ b/src/pnmio.c
@@ -1346,10 +1346,10 @@ l_int32   c, ignore;
     *pval = 0;
     if (!fp)
         return ERROR_INT("stream not open", procName, 1);
-    do {  /* skip whitespace */
+    do {  /* skip whitespace and non-numeric characters */
         if ((c = fgetc(fp)) == EOF)
             return 1;
-    } while (c == ' ' || c == '\t' || c == '\n' || c == '\r');
+    } while (!isdigit(c));
 
     fseek(fp, -1L, SEEK_CUR);        /* back up one byte */
     ignore = fscanf(fp, "%d", pval);


### PR DESCRIPTION
Programs that read this format should be as lenient as possible,
accepting anything that looks remotely like a pixmap.
See http://www.fileformat.info/format/pbm/egff.htm.

As other software (like for example convert) seems to ignore
non-digits in the input stream, do it here, too.

Signed-off-by: Stefan Weil <sw@weilnetz.de>