### PR TITLE
Added a target to pixa_recog_fuzzer

### DIFF
--- a/prog/fuzzing/pixa_recog_fuzzer.cc
+++ b/prog/fuzzing/pixa_recog_fuzzer.cc
@@ -17,9 +17,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         fwrite(data, size, 1, fp);
         fclose(fp);
 
-        PIXA      *pixa1, *pixa2, *pixa3, *pixa4;
+        PIXA      *pixa1, *pixa2, *pixa3, *pixa4, *pixa5;
         L_RECOG   *recog1, *recog2;
-        PIX       *pix1, *pix2;
+        PIX       *pix1, *pix2, *pix3, *pix4;
 
         pixa1 = pixaRead(filename);
 
@@ -28,18 +28,22 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         pixa2 = recogTrainFromBoot(recog1, pixa1, 0.75, 128, 1);
 
         pixa3 = pixaRemoveOutliers1(pixa1, 0.8, 4, 3, &pix1, &pix2);
+        pixa4 = pixaRemoveOutliers2(pixa1, 0.8, 4, &pix3, &pix4);
 
         recog2 = recogCreateFromPixa(pixa1, 4, 40, 1, 128, 1);
-        recogIdentifyMultiple(recog2, pix2, 0, 0, NULL, &pixa4, NULL, 1);
+        recogIdentifyMultiple(recog2, pix2, 0, 0, NULL, &pixa5, NULL, 1);
 
         pixDestroy(&pix1);
         pixDestroy(&pix2);
+        pixDestroy(&pix3);
+        pixDestroy(&pix4);
         recogDestroy(&recog1);
         recogDestroy(&recog2);
         pixaDestroy(&pixa1);
         pixaDestroy(&pixa2);
         pixaDestroy(&pixa3);
         pixaDestroy(&pixa4);
+        pixaDestroy(&pixa5);
         unlink(filename);
 
         return 0;


### PR DESCRIPTION
This PR adds pixaRemoveOutliers2() to the targets in the pixa_recog_fuzzer.
A few of the variable names have been rewritten to keep the order intact.