### PR TITLE
Added new fuzzer

### DIFF
--- a/prog/fuzzing/ccbord_fuzzer.cc
+++ b/prog/fuzzing/ccbord_fuzzer.cc
@@ -1,0 +1,27 @@
+#include "leptfuzz.h"
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+
+    if(size<3) return 0;
+
+    leptSetStdNullHandler();
+
+    PIX *pixs, *pixc;
+    CCBORDA *ccba;
+
+    pixs = pixReadMemSpix(data, size);
+    if(pixs==NULL) return 0;
+
+    ccba = pixGetAllCCBorders(pixs);
+    
+    ccbaStepChainsToPixCoords(ccba, CCB_GLOBAL_COORDS);
+    ccbaGenerateSPGlobalLocs(ccba, CCB_SAVE_TURNING_PTS);
+    pixc = ccbaDisplayImage2(ccba);
+
+    pixDestroy(&pixs);
+    pixDestroy(&pixc);
+    ccbaDestroy(&ccba);
+    return 0;
+}


### PR DESCRIPTION
This PR adds a new fuzzer that targets `ccbord.c`.

A small note on this fuzzer:
It runs out of memory fairly quickly, and it seems a leak is coming from `ccbaStepChainsToPixCoords()`.

It seems to me that everything is cleaned up the way it should be, and I appreciate any comments if that isn't the case.