### PR TITLE
Add allocation interception mechanism for embedded builds.

### DIFF
--- a/src/environ.h
+++ b/src/environ.h
@@ -329,12 +329,31 @@ typedef struct L_WallTimer  L_WALLTIMER;
  *  These specify the memory management functions that are used           *
  *  on all heap data except for Pix.  Memory management for Pix           *
  *  also defaults to malloc and free.  See pix1.c for details.            *
+ *                                                                        *
+ *  For builds where total interception of malloc/free are required,      *
+ *  define LEPTONICA_INTERCEPT_MALLOC, and provide your own               *
+ *  leptonica_{malloc,calloc,realloc,free} functions.                     *
  *------------------------------------------------------------------------*/
+#ifdef LEPTONICA_INTERCEPT_MALLOC
+
+#define LEPT_MALLOC(blocksize)           leptonica_malloc(blocksize)
+#define LEPT_CALLOC(numelem, elemsize)   leptonica_calloc(numelem, elemsize)
+#define LEPT_REALLOC(ptr, blocksize)     leptonica_realloc(ptr, blocksize)
+#define LEPT_FREE(ptr)                   leptonica_free(ptr)
+
+void *leptonica_malloc(size_t blocksize);
+void *leptonica_calloc(size_t numelm, size_t elemsize);
+void *leptonica_realloc(void *ptr, size_t blocksize);
+void leptonica_free(void *ptr);
+
+#else
+
 #define LEPT_MALLOC(blocksize)           malloc(blocksize)
 #define LEPT_CALLOC(numelem, elemsize)   calloc(numelem, elemsize)
 #define LEPT_REALLOC(ptr, blocksize)     realloc(ptr, blocksize)
 #define LEPT_FREE(ptr)                   free(ptr)
 
+#endif
 
 /*------------------------------------------------------------------------*
  *         Control printing of error, warning, and info messages          *

--- a/src/pix1.c
+++ b/src/pix1.c
@@ -228,8 +228,13 @@ struct PixMemoryManager
 
 /*! Default Pix memory manager */
 static struct PixMemoryManager  pix_mem_manager = {
+#ifdef LEPTONICA_INTERCEPT_MALLOC
+    &leptonica_malloc,
+    &leptonica_free
+#else
     &malloc,
     &free
+#endif
 };
 
 static void *
@@ -240,7 +245,7 @@ pix_malloc(size_t  size)
 #else  /* _MSC_VER */
     /* Under MSVC++, pix_mem_manager is initialized after a call
      * to pix_malloc.  Just ignore the custom allocator feature. */
-    return malloc(size);
+    return LEPT_MALLOC(size);
 #endif  /* _MSC_VER */
 }
 
@@ -252,7 +257,7 @@ pix_free(void  *ptr)
 #else  /* _MSC_VER */
     /* Under MSVC++, pix_mem_manager is initialized after a call
      * to pix_malloc.  Just ignore the custom allocator feature. */
-    free(ptr);
+    LEPT_FREE(ptr);
 #endif  /* _MSC_VER */
 }
 


### PR DESCRIPTION
Leptonica contains a setPixMemoryHandler mechanism for
intercepting allocations used for the data sections of
Pix (except on Windows where it is broken/disabled).
There is no mechanism for intercepting other such
allocations though.

Here, for the sake of embedded builds that need/want to
be able to control/track all allocations, we add such a
mechanism.

If LEPTONICA_INTERCEPT_MALLOC is defined during startup,
then all calls to malloc/calloc/realloc/free are redirected
to leptonica_{malloc/calloc/realloc/free} functions that
the library assumes will be provided for it.