### PR TITLE
Avoid warning when several version of openjpeg are installed

### DIFF
--- a/cmake/Configure.cmake
+++ b/cmake/Configure.cmake
@@ -145,20 +145,14 @@ file(APPEND ${AUTOCONFIG_SRC} "
 /* Define to 1 if you have zlib. */
 #cmakedefine HAVE_LIBZ 1
 
-#ifdef HAVE_OPENJPEG_2_0_OPENJPEG_H
-#define LIBJP2K_HEADER <openjpeg-2.0/openjpeg.h>
-#endif
-
-#ifdef HAVE_OPENJPEG_2_1_OPENJPEG_H
-#define LIBJP2K_HEADER <openjpeg-2.1/openjpeg.h>
-#endif
-
-#ifdef HAVE_OPENJPEG_2_2_OPENJPEG_H
-#define LIBJP2K_HEADER <openjpeg-2.2/openjpeg.h>
-#endif
-
-#ifdef HAVE_OPENJPEG_2_3_OPENJPEG_H
+#if defined(HAVE_OPENJPEG_2_3_OPENJPEG_H)
 #define LIBJP2K_HEADER <openjpeg-2.3/openjpeg.h>
+#elif defined(HAVE_OPENJPEG_2_2_OPENJPEG_H)
+#define LIBJP2K_HEADER <openjpeg-2.2/openjpeg.h>
+#elif defined(HAVE_OPENJPEG_2_1_OPENJPEG_H)
+#define LIBJP2K_HEADER <openjpeg-2.1/openjpeg.h>
+#elif defined(HAVE_OPENJPEG_2_0_OPENJPEG_H)
+#define LIBJP2K_HEADER <openjpeg-2.0/openjpeg.h>
 #endif
 ")
 


### PR DESCRIPTION
Currently, when several versions of openjpeg are found, LIBJP2K_HEADER is defined several times by cmake/Configure.cmake. gcc produces a warning `warning: "LIBJP2K_HEADER" redefined` on <build_dir>/src/config_auto.h

This patch ensures that LIBJP2K_HEADER is defined only once even when several versions of openjpeg are found.
It gives priority to the most recent version of openjpeg (2.3 > 2.2 > 2.1 > 2.0).