### PR TITLE
Removed assignment in adaptmap_fuzzer

### DIFF
--- a/prog/fuzzing/adaptmap_fuzzer.cc
+++ b/prog/fuzzing/adaptmap_fuzzer.cc
@@ -63,12 +63,9 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
 	pix1 = pixRead("../test8.jpg");
 	payload_copy = pixCopy(NULL, pixs_payload);
-	return_pix1 = pixContrastNorm(payload_copy, pix1, 10, 10, 3, 0, 0);
+	pixContrastNorm(payload_copy, pix1, 10, 10, 3, 0, 0);
 	pixDestroy(&pix1);
 	pixDestroy(&payload_copy);
-	if(return_pix1!=NULL){
-		pixDestroy(&return_pix1);
-	}
 
 
 	pix1 = pixRead("../test8.jpg");

--- a/prog/fuzzing/adaptmap_fuzzer.cc
+++ b/prog/fuzzing/adaptmap_fuzzer.cc
@@ -63,7 +63,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
 	pix1 = pixRead("../test8.jpg");
 	payload_copy = pixCopy(NULL, pixs_payload);
-	pixContrastNorm(payload_copy, pix1, 10, 10, 3, 0, 0);
+	pixContrastNorm(payload_copy, payload_copy, 10, 10, 3, 0, 0);
 	pixDestroy(&pix1);
 	pixDestroy(&payload_copy);
 


### PR DESCRIPTION
This PR removes the assignment of `pixContrastNorm` since the first parameter is not `NULL`