### PR TITLE
Don't free data which was passed to functions with copyflag L_INSERT

### DIFF
--- a/src/boxbasic.c
+++ b/src/boxbasic.c
@@ -645,7 +645,8 @@ BOX     *boxc;
     n = boxaGetCount(boxa);
     if (n >= boxa->nalloc) {
         if (boxaExtendArray(boxa)) {
-            boxDestroy(&boxc);
+            if (copyflag != L_INSERT)
+                boxDestroy(&boxc);
             return ERROR_INT("extension failed", procName, 1);
         }
     }

--- a/src/dnabasic.c
+++ b/src/dnabasic.c
@@ -1320,7 +1320,8 @@ L_DNA   *dac;
     n = l_dnaaGetCount(daa);
     if (n >= daa->nalloc) {
         if (l_dnaaExtendArray(daa)) {
-            l_dnaDestroy(&dac);
+            if (copyflag != L_INSERT)
+                l_dnaDestroy(&dac);
             return ERROR_INT("extension failed", procName, 1);
         }
     }

--- a/src/fpix1.c
+++ b/src/fpix1.c
@@ -780,7 +780,8 @@ FPIX    *fpixc;
     n = fpixaGetCount(fpixa);
     if (n >= fpixa->nalloc) {
         if (fpixaExtendArray(fpixa)) {
-            fpixDestroy(&fpixc);
+            if (copyflag != L_INSERT)
+                fpixDestroy(&fpixc);
             return ERROR_INT("extension failed", procName, 1);
         }
     }

--- a/src/numabasic.c
+++ b/src/numabasic.c
@@ -1568,7 +1568,8 @@ NUMA    *nac;
     n = numaaGetCount(naa);
     if (n >= naa->nalloc) {
         if (numaaExtendArray(naa)) {
-            numaDestroy(&nac);
+            if (copyflag != L_INSERT)
+                numaDestroy(&nac);
             return ERROR_INT("extension failed", procName, 1);
         }
     }

--- a/src/pixabasic.c
+++ b/src/pixabasic.c
@@ -531,7 +531,8 @@ PIX     *pixc;
     n = pixaGetCount(pixa);
     if (n >= pixa->nalloc) {
         if (pixaExtendArray(pixa)) {
-            pixDestroy(&pixc);
+            if (copyflag != L_INSERT)
+                pixDestroy(&pixc);
             return ERROR_INT("extension failed", procName, 1);
         }
     }
@@ -2019,7 +2020,8 @@ PIXA    *pixac;
     n = pixaaGetCount(paa, NULL);
     if (n >= paa->nalloc) {
         if (pixaaExtendArray(paa)) {
-            pixaDestroy(&pixac);
+            if (copyflag != L_INSERT)
+                pixaDestroy(&pixac);
             return ERROR_INT("extension failed", procName, 1);
         }
     }

--- a/src/ptabasic.c
+++ b/src/ptabasic.c
@@ -1058,7 +1058,8 @@ PTA     *ptac;
     n = ptaaGetCount(ptaa);
     if (n >= ptaa->nalloc) {
         if (ptaaExtendArray(ptaa)) {
-            ptaDestroy(&ptac);
+            if (copyflag != L_INSERT)
+                ptaDestroy(&ptac);
             return ERROR_INT("extension failed", procName, 1);
         }
     }

--- a/src/sel1.c
+++ b/src/sel1.c
@@ -601,7 +601,8 @@ SEL     *csel;
     n = selaGetCount(sela);
     if (n >= sela->nalloc) {
         if (selaExtendArray(sela)) {
-            selDestroy(&csel);
+            if (copyflag != L_INSERT)
+                selDestroy(&csel);
             return ERROR_INT("extension failed", procName, 1);
         }
     }


### PR DESCRIPTION
This fixes new duplicate free and use after free errors reported by
Coverity Scan.

Signed-off-by: Stefan Weil <sw@weilnetz.de>