### PR TITLE
Made temp directory creation respect the TMPDIR environment variable …

### DIFF
--- a/src/utils2.c
+++ b/src/utils2.c
@@ -3308,7 +3308,11 @@ size_t   pathlen;
         dir = pathJoin(result, subdir);
     }
 #else
-    dir = pathJoin("/tmp", subdir);
+    char *tmpDir = getenv("TMPDIR");
+    if (tmpDir == NULL) {
+        tmpDir = "/tmp";
+    }
+    dir = pathJoin(tmpDir, subdir);
 #endif /*  ~ OS_IOS */
 
 #ifndef _WIN32


### PR DESCRIPTION
…rather than forcing it inside /tmp directory.  When running inside some sandboxed environments /tmp will not be available.