### PR TITLE
makeTempDirname: use confstr on macOS, and fix a bug in path generation

### DIFF
--- a/src/utils2.c
+++ b/src/utils2.c
@@ -200,7 +200,7 @@
 #include <sys/types.h>
 #endif
 
-#ifdef OS_IOS
+#ifdef __APPLE__
 #include <unistd.h>
 #include <errno.h>
 #endif
@@ -3296,7 +3296,7 @@ size_t   pathlen;
 
     memset(result, 0, nbytes);
 
-#ifdef OS_IOS
+#ifdef __APPLE__
     {
         size_t n = confstr(_CS_DARWIN_USER_TEMP_DIR, result, nbytes);
         if (n == 0) {
@@ -3309,7 +3309,7 @@ size_t   pathlen;
     }
 #else
     dir = pathJoin("/tmp", subdir);
-#endif /*  ~ OS_IOS */
+#endif /*  ~ __APPLE__ */
 
 #ifndef _WIN32
     path = stringNew(dir);
@@ -3318,7 +3318,7 @@ size_t   pathlen;
 #endif  /*  ~ _WIN32 */
     pathlen = strlen(path);
     if (pathlen < nbytes - 1) {
-        stringCat(result, nbytes, path);
+        stringCopy(result, path, nbytes);
     } else {
         L_ERROR("result array too small for path\n", procName);
         ret = 1;


### PR DESCRIPTION
makeTempDirname() on iOS uses confstr() to get a temporary directory
because /tmp is not available to apps. macOS programs using the App
Sandbox are similarly restricted, and confstr is the recommended system
API to acquire a temporary directory path regardless.

This also fixes a bug introduced in
d15f1c24a16a65a4ae2e018a21ce9ad52b33ac64 where copying `path` to
`result` was changed from using strncpy() to stringCat(). Since the call
to confstr() already wrote to `result`, this led to the path being
incorrectly duplicated. Using stringCopy() resolves the issue.