### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ www.leptonica.org
   * Zdenko Podobny: Zdenko has worked, mostly behind the scenes as a primary maintainer of tesseract, to help with leptonica builds on all platforms, and coordinate with its use in tesseract.
   * Adam Korczynski: Adam is an expert in testing libraries for safety.  He has built most of the open source fuzzers for leptonica in the oss-fuzz project, with significant code coverage.
 
+## Installing leptonica (vcpkg)
+  * You can build and install leptonica using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+  ``` sh or powershell
+      git clone https://github.com/Microsoft/vcpkg.git
+      cd vcpkg
+      ./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
+      ./vcpkg integrate install
+      ./vcpkg install leptonica
+  ```
+
+  * The leptonica port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`leptonica` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `leptonica` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `leptonica`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/leptonica/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)