### PR TITLE
Fix rankhisto_reg test by fixing square root of negative number

### DIFF
--- a/prog/iomisc_reg.c
+++ b/prog/iomisc_reg.c
@@ -254,6 +254,7 @@ L_REGPARAMS  *rp;
     regTestCompareValues(rp, tiffsize[5], size, 0.0);  /* 29 */
     if (rp->display)
         lept_stderr("lzw: %ld\n", (unsigned long)size);
+    pixDestroy(&pixs);
 
         /* Test read/write of alpha with pnm */
     pixs = pixRead("books_logo.png");

--- a/prog/numa3_reg.c
+++ b/prog/numa3_reg.c
@@ -45,7 +45,7 @@ int main(int    argc,
          char **argv)
 {
 char          buf1[64], buf2[64];
-l_int32       i, n, hw, thresh, same, ival;
+l_int32       i, hw, thresh, same, ival;
 l_float32     val, maxval, rank;
 BOX          *box1;
 NUMA         *na, *nax, *nay, *nap, *nasy, *na1, *na2, *na3, *na4;
@@ -192,7 +192,7 @@ L_REGPARAMS  *rp;
     regTestWritePixAndCheck(rp, pixd, IFF_PNG);  /* 10 */
     pixDisplayWithTitle(pixd, 0, 500, NULL, rp->display);
     pixDestroy(&pixs);
-    pixDestroy(&pix2);
+    pixDestroy(&pix1);
     pixDestroy(&pixd);
     boxDestroy(&box1);
     numaDestroy(&na1);

--- a/src/pix5.c
+++ b/src/pix5.c
@@ -2886,6 +2886,9 @@ PTA        *pta;
         }
         ave = norm * sum1;
         var = norm * sum2 - ave * ave;
+        /* Avoid small negative values from rounding effects */
+        if (var < 0)
+            var = 0.0;
         rootvar = (l_float32)sqrt(var);
         numaAddNumber(nad, rootvar);
     }


### PR DESCRIPTION
The test fails in a debug build with compiler flag -ftrapv. That compiler flag modifies the code to detect illegal integer calculations.

An integer overflow was triggered because the difference of two floating point values was negative (rounding error) and the square root of negative values is undefined (NAN).

Converting NAN to integer results in an unexpected integer value.

Signed-off-by: Stefan Weil <sw@weilnetz.de>