### PR TITLE
fix crash by properly propagating error condition (out of heap memory / image too large)

### DIFF
--- a/src/jpegio.c
+++ b/src/jpegio.c
@@ -337,7 +337,10 @@ jmp_buf                        jmpbuf;  /* must be local to the function */
         rowbuffer = (JSAMPROW)LEPT_CALLOC(sizeof(JSAMPLE), w);
         pix = pixCreate(w, h, 8);
     }
-    pixSetInputFormat(pix, IFF_JFIF_JPEG);
+	if (!pix)
+		return (PIX*)ERROR_PTR("cannot load jpeg", __func__, NULL);
+
+	pixSetInputFormat(pix, IFF_JFIF_JPEG);
     if (!rowbuffer || !pix) {
         LEPT_FREE(rowbuffer);
         rowbuffer = NULL;


### PR DESCRIPTION
Fix: as it says on the tin.

## Context / background info

I ran into this one while testing a customized tesseract/leptonica combo, where I had made a mistake, which resulted in all JPEG and JP2 files failing to load because those libraries invoked a customized malloc/free wrapper, which just b0rked by returning NULL for every malloc attempt. 

> The original intent was that it SHOULD only do so for "ridiculously large malloc request sizes" but then I added an embarrassing primary school level calculus mistake and that made *everything* deemed "ridiculously oversized", hence the consistent NULL-only produce there. 😊 😰 

Thus the result is `pix` being NULL. leptonica has by now already reported something went wrong with the image memory allocation, but once it got here, `pix == NULL`, this caused a crash because the next few API methods were invoked with that NULLed `pix` and that didn't go down well. 💣 💥 

The added check fixes this by preventing NULL pointer dereferencing in this part of leptonica and properly returning to caller as quick as possible. With an additional error report added in for good measure. (In my case, when the custom malloc/free wrapper was still buggered, my code would produce a chain of about 5 leptonica error messages (from different spots in the call chain), before finally calling it quits and terminating in an orderly fashion. Which, AFAIAC, is nice behaviour. The number of error report lines might be reduced if you're nitpicking, but that is really very much UNimportant from my point of view; fixing the crash is important, however.
