### PR TITLE
introducing pixScaleBySamplingTopLeft, because sometimes we need (to visualize) pixel expansion from top/left rather than centre/centre.

### DIFF
--- a/src/allheaders.h
+++ b/src/allheaders.h
@@ -2415,6 +2415,7 @@ LEPT_DLL extern PIX * pixScaleGray2xLIDither ( PIX *pixs );
 LEPT_DLL extern PIX * pixScaleGray4xLIThresh ( PIX *pixs, l_int32 thresh );
 LEPT_DLL extern PIX * pixScaleGray4xLIDither ( PIX *pixs );
 LEPT_DLL extern PIX * pixScaleBySampling ( PIX *pixs, l_float32 scalex, l_float32 scaley );
+LEPT_DLL extern PIX * pixScaleBySamplingTopLeft (PIX *pixs, l_float32 scalex, l_float32 scaley);
 LEPT_DLL extern PIX * pixScaleBySamplingToSize ( PIX *pixs, l_int32 wd, l_int32 hd );
 LEPT_DLL extern PIX * pixScaleByIntSampling ( PIX *pixs, l_int32 factor );
 LEPT_DLL extern PIX * pixScaleRGBToGrayFast ( PIX *pixs, l_int32 factor, l_int32 color );

--- a/src/scale1.c
+++ b/src/scale1.c
@@ -96,6 +96,7 @@
  *
  *         Grayscale and color scaling by closest pixel sampling
  *               static l_int32    scaleBySamplingLow()
+ *               static l_int32    scaleBySamplingTopLeft()
  *
  *         Color and grayscale downsampling with (antialias) lowpass filter
  *               static l_int32    scaleSmoothLow()
@@ -140,6 +141,9 @@ static void scaleGray4xLILineLow(l_uint32 *lined, l_int32 wpld,
                                  l_uint32 *lines, l_int32 ws, l_int32 wpls,
                                  l_int32 lastlineflag);
 static l_int32 scaleBySamplingLow(l_uint32 *datad, l_int32 wd, l_int32 hd,
+                                  l_int32 wpld, l_uint32 *datas, l_int32 ws,
+                                  l_int32 hs, l_int32 d, l_int32 wpls);
+static l_int32 scaleBySamplingTopLeft(l_uint32 *datad, l_int32 wd, l_int32 hd,
                                   l_int32 wpld, l_uint32 *datas, l_int32 ws,
                                   l_int32 hs, l_int32 d, l_int32 wpls);
 static l_int32 scaleSmoothLow(l_uint32 *datad, l_int32 wd, l_int32 hd,
@@ -1336,6 +1340,67 @@ PIX       *pixd;
     datad = pixGetData(pixd);
     wpld = pixGetWpl(pixd);
     scaleBySamplingLow(datad, wd, hd, wpld, datas, ws, hs, d, wpls);
+    if (d == 32 && pixGetSpp(pixs) == 4)
+        pixScaleAndTransferAlpha(pixd, pixs, scalex, scaley);
+
+    return pixd;
+}
+
+
+/*------------------------------------------------------------------*
+ * Scaling by top/left pixel sampling, expanding from (0,0) down & left *
+ *------------------------------------------------------------------*/
+/*!
+ * \brief   pixScaleBySamplingTopLeft()
+ *
+ * \param[in]    pixs       1, 2, 4, 8, 16, 32 bpp
+ * \param[in]    scalex     must be > 0.0
+ * \param[in]    scaley     must be > 0.0
+ * \return  pixd, or NULL on error
+ *
+ * <pre>
+ * Notes:
+ *      (1) This function samples from the source without
+ *          filtering.  As a result, aliasing will occur for
+ *          subsampling (%scalex and/or %scaley < 1.0).
+ *      (2) If %scalex == 1.0 and %scaley == 1.0, returns a copy.
+ *      (3) For upscaling by an integer, use pixExpandReplicate().
+ * </pre>
+ */
+PIX *
+pixScaleBySamplingTopLeft(PIX       *pixs,
+                   l_float32  scalex,
+                   l_float32  scaley)
+{
+l_int32    ws, hs, d, wpls, wd, hd, wpld;
+l_uint32  *datas, *datad;
+PIX       *pixd;
+
+    if (!pixs)
+        return (PIX *)ERROR_PTR("pixs not defined", __func__, NULL);
+    if (scalex <= 0.0 || scaley <= 0.0)
+        return (PIX *)ERROR_PTR("scale factor <= 0", __func__, NULL);
+    if (scalex == 1.0 && scaley == 1.0)
+        return pixCopy(NULL, pixs);
+    if ((d = pixGetDepth(pixs)) == 1)
+        return pixScaleBinary(pixs, scalex, scaley);
+
+    pixGetDimensions(pixs, &ws, &hs, NULL);
+    datas = pixGetData(pixs);
+    wpls = pixGetWpl(pixs);
+    wd = (l_int32)(scalex * (l_float32)ws + 0.5);
+    hd = (l_int32)(scaley * (l_float32)hs + 0.5);
+    if ((pixd = pixCreate(wd, hd, d)) == NULL)
+        return (PIX *)ERROR_PTR("pixd not made", __func__, NULL);
+    pixCopyResolution(pixd, pixs);
+    pixScaleResolution(pixd, scalex, scaley);
+    pixCopyColormap(pixd, pixs);
+    pixCopyText(pixd, pixs);
+    pixCopyInputFormat(pixd, pixs);
+    pixCopySpp(pixd, pixs);
+    datad = pixGetData(pixd);
+    wpld = pixGetWpl(pixd);
+    scaleBySamplingTopLeft(datad, wd, hd, wpld, datas, ws, hs, d, wpls);
     if (d == 32 && pixGetSpp(pixs) == 4)
         pixScaleAndTransferAlpha(pixd, pixs, scalex, scaley);
 
@@ -3041,6 +3106,141 @@ l_float32  wratio, hratio;
         srow[i] = L_MIN((l_int32)(hratio * i + 0.5), hs - 1);
     for (j = 0; j < wd; j++)
         scol[j] = L_MIN((l_int32)(wratio * j + 0.5), ws - 1);
+
+    prevlines = NULL;
+    for (i = 0; i < hd; i++) {
+        lines = datas + srow[i] * wpls;
+        lined = datad + i * wpld;
+        if (lines != prevlines) {  /* make dest from new source row */
+            prevxs = -1;
+            sval = 0;
+            csval = 0;
+            if (d == 2) {
+                for (j = 0; j < wd; j++) {
+                    xs = scol[j];
+                    if (xs != prevxs) {  /* get dest pix from source col */
+                        sval = GET_DATA_DIBIT(lines, xs);
+                        SET_DATA_DIBIT(lined, j, sval);
+                        prevxs = xs;
+                    } else {  /* copy prev dest pix */
+                        SET_DATA_DIBIT(lined, j, sval);
+                    }
+                }
+            } else if (d == 4) {
+                for (j = 0; j < wd; j++) {
+                    xs = scol[j];
+                    if (xs != prevxs) {  /* get dest pix from source col */
+                        sval = GET_DATA_QBIT(lines, xs);
+                        SET_DATA_QBIT(lined, j, sval);
+                        prevxs = xs;
+                    } else {  /* copy prev dest pix */
+                        SET_DATA_QBIT(lined, j, sval);
+                    }
+                }
+            } else if (d == 8) {
+                for (j = 0; j < wd; j++) {
+                    xs = scol[j];
+                    if (xs != prevxs) {  /* get dest pix from source col */
+                        sval = GET_DATA_BYTE(lines, xs);
+                        SET_DATA_BYTE(lined, j, sval);
+                        prevxs = xs;
+                    } else {  /* copy prev dest pix */
+                        SET_DATA_BYTE(lined, j, sval);
+                    }
+                }
+            } else if (d == 16) {
+                for (j = 0; j < wd; j++) {
+                    xs = scol[j];
+                    if (xs != prevxs) {  /* get dest pix from source col */
+                        sval = GET_DATA_TWO_BYTES(lines, xs);
+                        SET_DATA_TWO_BYTES(lined, j, sval);
+                        prevxs = xs;
+                    } else {  /* copy prev dest pix */
+                        SET_DATA_TWO_BYTES(lined, j, sval);
+                    }
+                }
+            } else {  /* d == 32 */
+                for (j = 0; j < wd; j++) {
+                    xs = scol[j];
+                    if (xs != prevxs) {  /* get dest pix from source col */
+                        csval = lines[xs];
+                        lined[j] = csval;
+                        prevxs = xs;
+                    } else {  /* copy prev dest pix */
+                        lined[j] = csval;
+                    }
+                }
+            }
+        } else {  /* lines == prevlines; copy prev dest row */
+            prevlined = lined - wpld;
+            memcpy(lined, prevlined, 4 * wpld);
+        }
+        prevlines = lines;
+    }
+
+    LEPT_FREE(srow);
+    LEPT_FREE(scol);
+    return 0;
+}
+
+
+/*------------------------------------------------------------------*
+ *       Grayscale and color scaling by closest pixel sampling      *
+ *------------------------------------------------------------------*/
+/*!
+ * \brief   scaleBySamplingTopLeft()
+ *
+ * <pre>
+ * Notes:
+ *      (1) The dest must be cleared prior to this operation,
+ *          and we clear it here in the low-level code.
+ *      (2) We reuse dest pixels and dest pixel rows whenever
+ *          possible.  This speeds the upscaling; downscaling
+ *          is done by strict subsampling and is unaffected.
+ *      (3) Because we are sampling and not interpolating, this
+ *          routine works directly, without conversion to full
+ *          RGB color, for 2, 4 or 8 bpp palette color images.
+ * </pre>
+ */
+static l_int32
+scaleBySamplingTopLeft(l_uint32 *datad,
+                   l_int32    wd,
+                   l_int32    hd,
+                   l_int32    wpld,
+                   l_uint32  *datas,
+                   l_int32    ws,
+                   l_int32    hs,
+                   l_int32    d,
+                   l_int32    wpls)
+{
+l_int32    i, j;
+l_int32    xs, prevxs, sval;
+l_int32   *srow, *scol;
+l_uint32   csval;
+l_uint32  *lines, *prevlines, *lined, *prevlined;
+l_float32  wratio, hratio;
+
+    if (d != 2 && d != 4 && d !=8 && d != 16 && d != 32)
+        return ERROR_INT("pixel depth not supported", __func__, 1);
+
+        /* Clear dest */
+    memset(datad, 0, 4LL * hd * wpld);
+
+        /* the source row corresponding to dest row i ==> srow[i]
+         * the source col corresponding to dest col j ==> scol[j]  */
+    if ((srow = (l_int32 *)LEPT_CALLOC(hd, sizeof(l_int32))) == NULL)
+        return ERROR_INT("srow not made", __func__, 1);
+    if ((scol = (l_int32 *)LEPT_CALLOC(wd, sizeof(l_int32))) == NULL) {
+        LEPT_FREE(srow);
+        return ERROR_INT("scol not made", __func__, 1);
+    }
+
+    wratio = (l_float32)ws / (l_float32)wd;
+    hratio = (l_float32)hs / (l_float32)hd;
+    for (i = 0; i < hd; i++)
+        srow[i] = L_MIN((l_int32)(hratio * i), hs - 1);
+    for (j = 0; j < wd; j++)
+        scol[j] = L_MIN((l_int32)(wratio * j), ws - 1);
 
     prevlines = NULL;
     for (i = 0; i < hd; i++) {


### PR DESCRIPTION
 See the 'Dancing Troupe' comparative screenshots below for a use case.

## Context / Background info

OK, same custom leptonica + tesseract + others rig as in the previous pullreq.

Here, tesseract is augmented to produce a HTML report, including leptonica-style `PIX` images, all kept in a `PIXA` list.
While producing the report, I inspect each `PIX` image collected in that list and **blending** it with the 'original input image' in such a way that the new `PIX` is the top layer, while the 'original input image' is used as a bottom layer (think Photoshop layers), where that bottom layer is tinged *subdued red*. The blend is a custom one (because I was unable to produce the same using one or only a few standard leptonica API calls; I blame my n00bness re leptonica usage); the visual end result is that where-ever the top layer is WHITE (or rather: "pretty bright"), the "original image, but red tinted", "shines through", so you can easily observe processing artifacts which you might not want or expect. (red was chosen as that is similar to what you see when working in Photoshop, using Quick Masks, etc.)

For this to work with my custom hand-written blender code, both layers must have the same dimensions, hence the top layer is scaled up to match the bottom layer, when this is necessary. So far, so good. There *is* a catch however:

### Good: the new situation (using the new API `pixScaleBySamplingTopLeft`)

What we are looking at in the next screenshot is an extract of that custom tesseract diagnostic report with three images (note their reported width/height in pixels!)

The top image is the greyscaled "input" to a thresholding routine. 

The second image is the thresholding mask produced by that routine: it's quite a bit smaller than the top input image, but I scale it to the same size as the original before rendering it as PNG, as part of the HTML output and for the reason described above: for this one, nothing is "shining through" but that's okay. What matters here, and WHY `pixScaleBySamplingTopLeft` is used and useful here is: I want (the user) to see how we got from top + middle (threshold mask) to the bottom one (third PIX) in one easy flow. 

When you look at the bottom (third) image in the screenshot, you see "artifacts": the middle-bottom part is red-ish, because it got thresholded to *white* by way of those mask pixels, but that is probably undesirable as the original was pretty dark there, hence red-ish tint: the "locality" of the thresholding is failing us here. **No problem** (**not for this pullreq anyway**), but exactly the kind of thing I want to see: top + middle, mixed, produces bottom. 👍 

We see the thresholding algorithm at work: 

![msedge_good_crop](https://user-images.githubusercontent.com/402462/223873893-578f60ab-fb29-4845-8d05-3e818af77e4b.png)

### Bad: the previous situation (using the existing API `pixScaleBySampling`)

This requires a bit of an explanation, but **TL;DR**: let me show you what that `pixScaleBySampling` API call delivered, all else **exactly the same**:

here the scaled mask image (the middle one) looks "sampled" (good), **but** looks like it's oddly *shifted* by half a pixel left/up: pay particular attention to the reported pixel dimensions and keep in mind: top image mixed with this (sampled by thresholding algorithm) middle image produces bottom image. *That does not look right!* 🤔 ❓ Making this visual a headscratcher. Which is "bad":

![msedge_bad_crop](https://user-images.githubusercontent.com/402462/223875404-556cc8ba-e487-45dc-bc69-98863b224305.png)

### Bad (v0.0.1) or how we got to use `pixScaleBySampling` in the first place: `pixScale`

Please remember: I'm a leptonica n00b, so I do my doc read, I do some RTFC (because the docs don't always link up properly with my brain), I do some `grep`, and hope to not embarrass myself *too much*. 😉 

This is what I got when I had "something working for the first time": I had decided `pixScale` was probably the initially-sanest answer to my quest re scaling up small images to "original image size": note those three reported images' width/height pixel dimensions in the screenshot again; nothing has changed, only this time I call `pixScale` as I did initially:

Please remember the goal here is to visualize: top mixed with middle (threshold level mask) produces bottom result *somehow*.  Thanks to `pixScale`, the middle image gets scaled in a rather *smooth* fashion and to my *dotard* brain, **as a user of those images** I can't comprehend how the heck top + middle mixed makes bottom one: 😕

![msedge_bad-old_crop](https://user-images.githubusercontent.com/402462/223876234-8826bdd0-3862-4143-b886-9b9d04c4852a.png)

Which is the reason why I dug into leptonica some more after this first attempt and dove up `pixScaleBySampling` because I was looking for an upscaling that *specifically* DID NOT interpolate / smooth / otherwise-mix adjacent source pixels in the scaling up as the artifacts I was wondering about in the *bottom* image needed some explanation and my *guess* was that the crazy stuff I saw in the bottom ones (this "Dancing Troupe" is only one example and certainly not the "weirdest" of the bunch!) is possibly due to the sampling method used by the alleged thresholding algorithm. 

Hence `pixScaleBySampling` popping up as *prime candidate*. 👍 

Which got me another *WTF* as I was now looking at some oddly-overlarge bottom pixel row in the mask and the next *think* was: *why* is this middle one suddenly *shifted* when I call `pixScaleBySampling`? What am *I* doing wrong?!

Which took some time, but landed me at "I don't know, but when I do *this* (`pixScaleBySamplingTopLeft`), my expectations match application output reality. ... 🤔  and maybe file a pullreq if a second RTFC doesn't tell me I've redone something that's already present anyway. 

Sorry, couldn't find what I hoped to find, so here is `pixScaleBySampling`, duplicated and then **corrected for my use case** by dropping the two `+ 0.5` pixel position calculus expressions: that is the entire difference between `pixScaleBySamplingTopLeft` and `pixScaleBySampling`.

-------------

## The End

I hope I didn't embarrass myself by completely overlooking leptonica API `XYZ`. 😅 


## PS: and that "Otsu thresholding algorithm"?! Code or it didn't happen!

```
std::tuple<bool, Image, Image, Image> ImageThresholder::Threshold(
                                                      ThresholdMethod method) {
  Image pix_binary = nullptr;
  Image pix_thresholds = nullptr;

  // ### useless/irrelevant code: *snip*

  auto pix_grey = GetPixRectGrey();

  int r = 0;
  l_int32 threshold_val = 0;

  l_int32 pix_w, pix_h;
  pixGetDimensions(pix_ /* pix_grey */, &pix_w, &pix_h, nullptr);

  if (tesseract_->thresholding_debug) {
    tprintf("\nimage width: {}  height: {}  ppi: {}\n", pix_w, pix_h, yres_);
  }

  if (method == ThresholdMethod::Sauvola) {
  // ### useless/irrelevant code: *snip*
  } else if (method == ThresholdMethod::LeptonicaOtsu) {
    int tile_size;
    double tile_size_factor = tesseract_->thresholding_tile_size;
    tile_size = tile_size_factor * yres_;
    tile_size = std::max(16, tile_size);

    int smooth_size;
    double smooth_size_factor = tesseract_->thresholding_smooth_kernel_size;
    smooth_size_factor = std::max(0.0, smooth_size_factor);
    smooth_size = smooth_size_factor * yres_;
    int half_smooth_size = smooth_size / 2;

    double score_fraction = tesseract_->thresholding_score_fraction;

    if (tesseract_->thresholding_debug) {
      tprintf("tile size: {}  smooth_size: {}  score_fraction: {}\n", tile_size, smooth_size, score_fraction);
    }

    // ### TADA! It wasn't me!   ;-)
    r = pixOtsuAdaptiveThreshold(pix_grey, tile_size, tile_size,
                                 half_smooth_size, half_smooth_size,
                                 score_fraction,
                                 (PIX **)pix_thresholds,
                                 (PIX **)pix_binary);
  } else if (method == ThresholdMethod::Nlbin) {
  // ### useless/irrelevant code: *snip*
  } else {
    // Unsupported threshold method.
    r = 1;
  }

  bool ok = (r == 0) && pix_binary;
  return std::make_tuple(ok, pix_grey, pix_binary, pix_thresholds);
}
```

... and then, through magic, that tuple lands in a `PIXA`, which I take to make an HTML, and we get the story above.



## PPS: 🤔 hm, that half-pixel-to-the-top-left-SHIFT is *everywhere*?

Now that I write this pullreq, only now do I notice that that half-pixel SHIFT is also **already present** in the `pixScale` scaled-up output image. If you know -- with 20:20 hindsight -- what to look for: see the image dimensions, where the height is 3 pixels, and notice again that the 'linearly smoothed' `pixScale`-produced image also has a 'thinner' top row vs. a 'over-thick' bottom row, exactly like `pixScaleBySampling`, where it was so obviously visible: last screenshot repeated here for convenience: check the middle image (`pixScale` output):

![msedge_bad-old_crop](https://user-images.githubusercontent.com/402462/223879837-22f83ccf-ba1e-43b8-b40a-d2bb3bce73fb.png)

Is this what we (you?) want, **by design**? Or is this an artifact that nobody's noticed up to now? Or... (fill in the blanks; n00b may be completely off his rocker.) ❓ 🤔 

------------

Thanks for a very nice library; all misunderstandings/incomprehensions are mine. 
Compare this to RTFC-ing OpenCV, for example, and I know why I've been, *äh*, "ambivalent" about working with & on *that one*, despite the lure of some desirable magic tech in there. 
At least I can grok this leptonica code and get results I want in a couple of weeks and still gaining speed (of coding). 👍 



















