### PR TITLE
always use the UTF8/ANSI Win32 APIs (MSVC, Unicode builds)

### DIFF
--- a/src/utils2.c
+++ b/src/utils2.c
@@ -2166,9 +2166,9 @@ l_uint32  attributes;
 #ifndef _WIN32
     ret = mkdir(dir, 0777);
 #else
-    attributes = GetFileAttributes(dir);
+    attributes = GetFileAttributesA(dir);
     if (attributes == INVALID_FILE_ATTRIBUTES)
-        ret = (CreateDirectory(dir, NULL) ? 0 : 1);
+        ret = (CreateDirectoryA(dir, NULL) ? 0 : 1);
 #endif
         /* Make all the subdirectories */
     for (i = 0; i < n; i++) {
@@ -2176,8 +2176,8 @@ l_uint32  attributes;
 #ifndef _WIN32
         ret += mkdir(tmpdir, 0777);
 #else
-        if (CreateDirectory(tmpdir, NULL) == 0)
-            ret += (GetLastError () != ERROR_ALREADY_EXISTS);
+        if (CreateDirectoryA(tmpdir, NULL) == 0)
+            ret += (GetLastError() != ERROR_ALREADY_EXISTS);
 #endif
         LEPT_FREE(dir);
         dir = tmpdir;
@@ -2214,11 +2214,13 @@ l_uint32  attributes;
 l_int32
 lept_rmdir(const char  *subdir)
 {
-char    *dir, *realdir, *fname, *fullname;
+char    *dir, *fname, *fullname;
 l_int32  exists, ret, i, nfiles;
 SARRAY  *sa;
 #ifdef _WIN32
 char    *newpath;
+#else
+char    *realdir;
 #endif  /* _WIN32 */
 
     if (!subdir)
@@ -2257,7 +2259,7 @@ char    *newpath;
     LEPT_FREE(realdir);
 #else
     newpath = genPathname(dir, NULL);
-    ret = (RemoveDirectory(newpath) ? 0 : 1);
+    ret = (RemoveDirectoryA(newpath) ? 0 : 1);
     LEPT_FREE(newpath);
 #endif  /* !_WIN32 */
 
@@ -2305,7 +2307,7 @@ char  *realdir;
 #else  /* _WIN32 */
     {
     l_uint32  attributes;
-    attributes = GetFileAttributes(realdir);
+    attributes = GetFileAttributesA(realdir);
     if (attributes != INVALID_FILE_ATTRIBUTES &&
         (attributes & FILE_ATTRIBUTE_DIRECTORY))
         *pexists = 1;
@@ -2439,8 +2441,8 @@ l_int32  ret;
     ret = remove(filepath);
 #else
         /* Set attributes to allow deletion of read-only files */
-    SetFileAttributes(filepath, FILE_ATTRIBUTE_NORMAL);
-    ret = DeleteFile(filepath) ? 0 : 1;
+    SetFileAttributesA(filepath, FILE_ATTRIBUTE_NORMAL);
+    ret = DeleteFileA(filepath) ? 0 : 1;
 #endif  /* !_WIN32 */
 
     return ret;
@@ -2530,7 +2532,7 @@ l_int32  ret;
     LEPT_FREE(srctail);
 
         /* Overwrite any existing file at 'newpath' */
-    ret = MoveFileEx(srcpath, newpath,
+    ret = MoveFileExA(srcpath, newpath,
                      MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING) ? 0 : 1;
 #endif  /* ! _WIN32 */
 
@@ -2622,7 +2624,7 @@ l_int32  ret;
     LEPT_FREE(srctail);
 
         /* Overwrite any existing file at 'newpath' */
-    ret = CopyFile(srcpath, newpath, FALSE) ? 0 : 1;
+    ret = CopyFileA(srcpath, newpath, FALSE) ? 0 : 1;
 #endif   /* !_WIN32 */
 
     LEPT_FREE(srcpath);
@@ -3118,7 +3120,7 @@ size_t   size;
 #ifdef _WIN32
         l_int32 tmpdirlen;
         char tmpdir[MAX_PATH];
-        GetTempPath(sizeof(tmpdir), tmpdir);  /* get the Windows temp dir */
+        GetTempPathA(sizeof(tmpdir), tmpdir);  /* get the Windows temp dir */
         tmpdirlen = strlen(tmpdir);
         if (tmpdirlen > 0 && tmpdir[tmpdirlen - 1] == '\\') {
             tmpdir[tmpdirlen - 1] = '\0';  /* trim the trailing '\' */
@@ -3309,7 +3311,7 @@ char  dirname[240];
 {
     char  fname[MAX_PATH];
     FILE *fp;
-    if (GetTempFileName(dirname, "lp.", 0, fname) == 0)
+    if (GetTempFileNameA(dirname, "lp.", 0, fname) == 0)
         return (char *)ERROR_PTR("GetTempFileName failed", __func__, NULL);
     if ((fp = fopen(fname, "wb")) == NULL)
         return (char *)ERROR_PTR("file cannot be written to", __func__, NULL);


### PR DESCRIPTION
always use the UTF8/ANSI Win32 APIs, whether the code is built in Ansi/MBCS or Unicode (16-bit TCHAR) mode (MSVC: /Unicode flag)

---

> These show up when compiling the code in `/Unicode` mode, which is our in-house setting for all projects. Don't know if this 'reachable' via the provided cmake, as I don't use that one for Windows.