### PR TITLE
configure.ac: Update minimum required autoconf version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.50])
+AC_PREREQ([2.69])
 AC_INIT([leptonica], [1.84.0])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_HEADERS([config_auto.h:config/config.h.in])


### PR DESCRIPTION
Version 2.50 was released in 2001. Version 2.69 was released in 2012.
Version 2.70 was released in 2020. The last version is 2.71.