### PR TITLE
minor Numa safety patches

### DIFF
--- a/src/colorquant1.c
+++ b/src/colorquant1.c
@@ -3110,7 +3110,8 @@ PIXCMAP   *cmap;
     makeRGBToIndexTables(level, &rtab, &gtab, &btab);
 
         /* The octarray will give a ptr from the octcube to the colorarray */
-    ncubes = numaGetCount(na);
+    if ((ncubes = numaGetCount(na)) == 0)
+        return ERROR_PTR("no slots in pixel occupation histogram", __func__, NULL);
     octarray = (l_int32 *)LEPT_CALLOC(ncubes, sizeof(l_int32));
 
         /* The colorarray will hold the colors of the first pixel

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1152,6 +1152,7 @@ PTA       *pta1, *pta2, *ptad;
 
         /* Generate the plot points */
     pta1 = ptaCreate(n);
+    maxw = maxh = 0;       
     for (i = 0; i < n; i++) {
         numaGetFValue(na, i, &val);
         if (orient == L_HORIZONTAL_LINE) {

--- a/src/numabasic.c
+++ b/src/numabasic.c
@@ -812,7 +812,8 @@ l_int32  *array;
     if (!na)
         return (l_int32 *)ERROR_PTR("na not defined", __func__, NULL);
 
-    n = numaGetCount(na);
+    if ((n = numaGetCount(na)) == 0)
+        return ERROR_PTR("array not made (na is empty)", __func__, NULL);
     if ((array = (l_int32 *)LEPT_CALLOC(n, sizeof(l_int32))) == NULL)
         return (l_int32 *)ERROR_PTR("array not made", __func__, NULL);
     for (i = 0; i < n; i++) {
@@ -859,7 +860,8 @@ l_float32  *array;
     if (copyflag == L_NOCOPY) {
         array = na->array;
     } else {  /* copyflag == L_COPY */
-        n = numaGetCount(na);
+        if ((n = numaGetCount(na)) == 0)
+            return ERROR_PTR("array not made (na is empty)", __func__, NULL);
         if ((array = (l_float32 *)LEPT_CALLOC(n, sizeof(l_float32))) == NULL)
             return (l_float32 *)ERROR_PTR("array not made", __func__, NULL);
         for (i = 0; i < n; i++)

--- a/src/numafunc2.c
+++ b/src/numafunc2.c
@@ -1613,6 +1613,7 @@ l_float32  startval, binsize, rankcount, total, sum, fract, val;
     numaGetSum(na, &total);
     rankcount = rank * total;  /* count that corresponds to rank */
     sum = 0.0;
+    val = 0.0;
     for (i = 0; i < n; i++) {
         numaGetFValue(na, i, &val);
         if (sum + val >= rankcount)


### PR DESCRIPTION
See also the commit messages... I hit upon these thanks to my own misuse of one these APIs (unintentionally feeding it a NUMA array of zero length) and I got some random weird results with MSVC2022, then I investigated and found `numaGetCount() == 0` was not reckoned with. Followed up that one with an overall code review and fixed all the spots where the code for the `count == 0` scenario was either non-trivial or would potentially produce random/garbage results.

(For example, a zero-length calloc on my system is a hard fail because it's way too often indicative of faulty coding somewhere, so I won't wait for `LEPT_CALLOC` to b0rk with a NULL return. This is more... pedantic than one may expect on Linuxes in general.)