### PR TITLE
Use atomic operations for some index variables

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -971,7 +971,7 @@ pixCompareGray(PIX        *pix1,
                PIX       **ppixdiff)
 {
 char            buf[64];
-static l_int32  index = 0;
+static l_atomic index = 0;
 l_int32         d1, d2, same, first, last;
 GPLOT          *gplot;
 NUMA           *na, *nac;
@@ -1078,7 +1078,7 @@ pixCompareRGB(PIX        *pix1,
               PIX       **ppixdiff)
 {
 char            buf[64];
-static l_int32  index = 0;
+static l_atomic index = 0;
 l_int32         rsame, gsame, bsame, same, first, rlast, glast, blast, last;
 l_float32       rdiff, gdiff, bdiff;
 GPLOT          *gplot;

--- a/src/gplot.c
+++ b/src/gplot.c
@@ -761,7 +761,7 @@ gplotSimplePix1(NUMA        *na,
                 const char  *title)
 {
 char            buf[64];
-static l_int32  index;
+static l_atomic index;
 GPLOT          *gplot;
 PIX            *pix;
 
@@ -803,7 +803,7 @@ gplotSimplePix2(NUMA        *na1,
                 const char  *title)
 {
 char            buf[64];
-static l_int32  index;
+static l_atomic index;
 GPLOT          *gplot;
 PIX            *pix;
 
@@ -844,7 +844,7 @@ gplotSimplePixN(NUMAA       *naa,
                 const char  *title)
 {
 char            buf[64];
-static l_int32  index;
+static l_atomic index;
 GPLOT          *gplot;
 PIX            *pix;
 

--- a/src/regutils.h
+++ b/src/regutils.h
@@ -120,7 +120,7 @@ struct L_RegParams
     char    *testname;  /*!< name of test, without '_reg'                     */
     char    *tempfile;  /*!< name of temp file for compare mode output        */
     l_int32  mode;      /*!< generate, compare or display                     */
-    l_int32  index;     /*!< index into saved files for this test; 0-based    */
+    l_atomic index;     /*!< index into saved files for this test; 0-based    */
     l_int32  success;   /*!< overall result of the test                       */
     l_int32  display;   /*!< 1 if in display mode; 0 otherwise                */
     L_TIMER  tstart;    /*!< marks beginning of the reg test                  */

--- a/src/writefile.c
+++ b/src/writefile.c
@@ -924,7 +924,7 @@ pixDisplayWithTitle(PIX         *pixs,
 {
 char           *tempname;
 char            buffer[Bufsize];
-static l_int32  index = 0;  /* caution: not .so or thread safe */
+static l_atomic index = 0;  /* caution: not .so safe */
 l_int32         w, h, d, spp, maxheight, opaque, threeviews;
 l_float32       ratw, rath, ratmin;
 PIX            *pix0, *pix1, *pix2;


### PR DESCRIPTION
This makes the related functions thread safe, but calling them from different processes will still cause problems because all processes use the same filenames which are generated by using the index.