### PR TITLE
Remove redundant assignment (fixes compiler warning)

### DIFF
--- a/src/jp2kio.c
+++ b/src/jp2kio.c
@@ -723,7 +723,6 @@ opj_image_cmptparm_t  cmptparm[4];
     memset(&cmptparm[0], 0, 4 * sizeof(opj_image_cmptparm_t));
     for (i = 0; i < spp; i++) {
         cmptparm[i].prec = 8;
-        cmptparm[i].bpp = 8;
         cmptparm[i].sgnd = 0;
         cmptparm[i].dx = 1;
         cmptparm[i].dy = 1;


### PR DESCRIPTION
The member variable bpp is deprecated and a synonym for the member variable prec, which already has the same value assigned to it, so remove the redundant assignment to bpp. This fixes a compiler warning:

src/jp2kio.c: In function 'pixConvertToOpjImage':
src/jp2kio.c:726:9: warning: 'bpp' is deprecated: Use prec instead [-Wdeprecated-declarations]
  726 |         cmptparm[i].bpp = 8;
      |         ^~~~~~~~