### PR TITLE
Fix some compiler warnings for unused local variables

### DIFF
--- a/src/colormap.c
+++ b/src/colormap.c
@@ -1787,7 +1787,7 @@ PIXCMAP  *cmap;
 PIXCMAP *
 pixcmapReadStream(FILE  *fp)
 {
-l_int32   rval, gval, bval, aval, ignore;
+l_int32   rval, gval, bval, aval;
 l_int32   i, index, ret, depth, ncolors;
 PIXCMAP  *cmap;
 
@@ -1800,8 +1800,8 @@ PIXCMAP  *cmap;
         (depth != 1 && depth != 2 && depth != 4 && depth != 8) ||
         (ncolors < 2 || ncolors > 256))
         return (PIXCMAP *)ERROR_PTR("invalid cmap size", __func__, NULL);
-    ignore = fscanf(fp, "Color    R-val    G-val    B-val   Alpha\n");
-    ignore = fscanf(fp, "----------------------------------------\n");
+    (void)fscanf(fp, "Color    R-val    G-val    B-val   Alpha\n");
+    (void)fscanf(fp, "----------------------------------------\n");
 
     if ((cmap = pixcmapCreate(depth)) == NULL)
         return (PIXCMAP *)ERROR_PTR("cmap not made", __func__, NULL);

--- a/src/gplot.c
+++ b/src/gplot.c
@@ -1206,8 +1206,8 @@ GPLOT *
 gplotRead(const char  *filename)
 {
 char     buf[Bufsize];
-char    *rootname, *title, *xlabel, *ylabel, *ignores;
-l_int32  outformat, ret, version, ignore;
+char    *rootname, *title, *xlabel, *ylabel;
+l_int32  outformat, ret, version;
 FILE    *fp;
 GPLOT   *gplot;
 
@@ -1230,16 +1230,16 @@ GPLOT   *gplot;
                                     filename, __func__, NULL);
     }
 
-    ignore = fscanf(fp, "Rootname: %511s\n", buf);  /* Bufsize - 1 */
+    (void)fscanf(fp, "Rootname: %511s\n", buf);  /* Bufsize - 1 */
     rootname = stringNew(buf);
-    ignore = fscanf(fp, "Output format: %d\n", &outformat);
-    ignores = fgets(buf, Bufsize, fp);   /* Title: ... */
+    (void)fscanf(fp, "Output format: %d\n", &outformat);
+    (void)fgets(buf, Bufsize, fp);   /* Title: ... */
     title = stringNew(buf + 7);
     title[strlen(title) - 1] = '\0';
-    ignores = fgets(buf, Bufsize, fp);   /* X axis label: ... */
+    (void)fgets(buf, Bufsize, fp);   /* X axis label: ... */
     xlabel = stringNew(buf + 14);
     xlabel[strlen(xlabel) - 1] = '\0';
-    ignores = fgets(buf, Bufsize, fp);   /* Y axis label: ... */
+    (void)fgets(buf, Bufsize, fp);   /* Y axis label: ... */
     ylabel = stringNew(buf + 14);
     ylabel[strlen(ylabel) - 1] = '\0';
 
@@ -1258,23 +1258,23 @@ GPLOT   *gplot;
     sarrayDestroy(&gplot->plotlabels);
     numaDestroy(&gplot->plotstyles);
 
-    ignore = fscanf(fp, "Commandfile name: %s\n", buf);  /* Bufsize - 1 */
+    (void)fscanf(fp, "Commandfile name: %s\n", buf);  /* Bufsize - 1 */
     stringReplace(&gplot->cmdname, buf);
-    ignore = fscanf(fp, "\nCommandfile data:");
+    (void)fscanf(fp, "\nCommandfile data:");
     gplot->cmddata = sarrayReadStream(fp);
-    ignore = fscanf(fp, "\nDatafile names:");
+    (void)fscanf(fp, "\nDatafile names:");
     gplot->datanames = sarrayReadStream(fp);
-    ignore = fscanf(fp, "\nPlot data:");
+    (void)fscanf(fp, "\nPlot data:");
     gplot->plotdata = sarrayReadStream(fp);
-    ignore = fscanf(fp, "\nPlot titles:");
+    (void)fscanf(fp, "\nPlot titles:");
     gplot->plotlabels = sarrayReadStream(fp);
-    ignore = fscanf(fp, "\nPlot styles:");
+    (void)fscanf(fp, "\nPlot styles:");
     gplot->plotstyles = numaReadStream(fp);
 
-    ignore = fscanf(fp, "Number of plots: %d\n", &gplot->nplots);
-    ignore = fscanf(fp, "Output file name: %s\n", buf);
+    (void)fscanf(fp, "Number of plots: %d\n", &gplot->nplots);
+    (void)fscanf(fp, "Output file name: %s\n", buf);
     stringReplace(&gplot->outname, buf);
-    ignore = fscanf(fp, "Axis scaling: %d\n", &gplot->scaling);
+    (void)fscanf(fp, "Axis scaling: %d\n", &gplot->scaling);
 
     fclose(fp);
     return gplot;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -537,7 +537,7 @@ L_KERNEL  *kel;
 L_KERNEL *
 kernelReadStream(FILE  *fp)
 {
-l_int32    sy, sx, cy, cx, i, j, ret, version, ignore;
+l_int32    sy, sx, cy, cx, i, j, ret, version;
 L_KERNEL  *kel;
 
     if (!fp)
@@ -562,10 +562,10 @@ L_KERNEL  *kel;
 
     for (i = 0; i < sy; i++) {
         for (j = 0; j < sx; j++)
-            ignore = fscanf(fp, "%15f", &kel->data[i][j]);
-        ignore = fscanf(fp, "\n");
+            (void)fscanf(fp, "%15f", &kel->data[i][j]);
+        (void)fscanf(fp, "\n");
     }
-    ignore = fscanf(fp, "\n");
+    (void)fscanf(fp, "\n");
 
     return kel;
 }

--- a/src/pnmio.c
+++ b/src/pnmio.c
@@ -1327,8 +1327,6 @@ static l_int32
 pnmReadNextAsciiValue(FILE     *fp,
                       l_int32  *pval)
 {
-l_int32  ignore;
-
     if (!pval)
         return ERROR_INT("&val not defined", __func__, 1);
     *pval = 0;

--- a/src/sarray1.c
+++ b/src/sarray1.c
@@ -1387,7 +1387,7 @@ SARRAY *
 sarrayReadStream(FILE  *fp)
 {
 char    *stringbuf;
-l_int32  i, n, size, index, bufsize, version, ignore, success;
+l_int32  i, n, size, index, bufsize, version, success;
 SARRAY  *sa;
 
     if (!fp)
@@ -1435,7 +1435,7 @@ SARRAY  *sa;
             /* Copy it in, skipping the 2 leading spaces */
         sarrayAddString(sa, stringbuf + 2, L_COPY);
     }
-    ignore = fscanf(fp, "\n");
+    (void)fscanf(fp, "\n");
 
 cleanup:
     LEPT_FREE(stringbuf);

--- a/src/sel1.c
+++ b/src/sel1.c
@@ -1351,7 +1351,7 @@ selReadStream(FILE  *fp)
 {
 char     selname[256];
 char     linebuf[256];
-l_int32  sy, sx, cy, cx, i, j, version, ignore;
+l_int32  sy, sx, cy, cx, i, j, version;
 SEL     *sel;
 
     if (!fp)
@@ -1375,12 +1375,12 @@ SEL     *sel;
     selSetOrigin(sel, cy, cx);
 
     for (i = 0; i < sy; i++) {
-        ignore = fscanf(fp, "    ");
+        (void)fscanf(fp, "    ");
         for (j = 0; j < sx; j++)
-            ignore = fscanf(fp, "%1d", &sel->data[i][j]);
-        ignore = fscanf(fp, "\n");
+            (void)fscanf(fp, "%1d", &sel->data[i][j]);
+        (void)fscanf(fp, "\n");
     }
-    ignore = fscanf(fp, "\n");
+    (void)fscanf(fp, "\n");
 
     return sel;
 }


### PR DESCRIPTION
Instead of assigning the return value to an otherwise unused variable (which also raises a compiler warning), use a cast to void to explicitly indicate that the return value is intentionally ignored.

Calling system() without checking the return value does not raise a compiler warning, so don't add the cast for those calls.