### PR TITLE
cmake: fix library name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 add_library                     (leptonica ${src} ${hdr})
 set_target_properties           (leptonica PROPERTIES VERSION   6.0.0)
 set_target_properties           (leptonica PROPERTIES SOVERSION 6)
-set_target_properties           (leptonica PROPERTIES OUTPUT_NAME leptonica$<$<BOOL:${WIN32}>:-${PROJECT_VERSION}$<$<CONFIG:DEBUG>:d>>)
+set_target_properties           (leptonica PROPERTIES OUTPUT_NAME leptonica$<$<BOOL:${MSVC}>:-${PROJECT_VERSION}$<$<CONFIG:DEBUG>:d>>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions  (leptonica PRIVATE -DLIBLEPT_EXPORTS)


### PR DESCRIPTION
For CYGWIN/MSYS/MINGW, libraries should be named the same as UNIX.