### PR TITLE
Replace sh by bash for reg_wrapper.sh and fix test for working gnuplot

### DIFF
--- a/prog/reg_wrapper.sh
+++ b/prog/reg_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 #  This testing wrapper was written by James Le Cuirot.
 #

--- a/prog/reg_wrapper.sh
+++ b/prog/reg_wrapper.sh
@@ -40,7 +40,7 @@ case "${TEST_NAME}" in
     baseline|boxa[1234]|colormask|colorspace|crop|dna|enhance|extrema|fpix1|hash|italic|kernel|nearline|numa[123]|pixa1|projection|rank|rankbin|rankhisto|wordboxes)
         GNUPLOT=$(which gnuplot || which wgnuplot)
 
-        if [ -z "${GNUPLOT}" ] || ! "${GNUPLOT}" -e "set terminal png" 2>/dev/null ; then
+        if [ -z "${GNUPLOT}" ] || [ -n "$(${GNUPLOT} -e 'set terminal png' 2>&1)" ] ; then
             exec ${@%${TEST}} /bin/sh -c "exit 77"
         fi
 esac


### PR DESCRIPTION
Some older versions of /bin/sh don't work.
This was noticed in a test on Solaris 11.4 (SPARC) with sh (AT&T Research) 93u+ 2012-08-01.

Instead of using /bin/bash the script now finds bash with /usr/bin/env, so it will use the latest bash on systems like macOS.

Fix also the test for a working gnuplot.

`gnuplot -e "set terminal png"` does not return an error if the command fails, but prints an error message.

So instead of checking for an error the test now checks for a non-empty output.

This fixes `make check` on hosts with a gnuplot which does not support `set terminal png`.
