### PR TITLE
Fix warnings for builds with clang compiler

### DIFF
--- a/prog/partition_reg.c
+++ b/prog/partition_reg.c
@@ -41,9 +41,9 @@
 
 #include "allheaders.h"
 
-void  TestPartition(L_REGPARAMS *rp, const char *fname, l_int32 sorttype,
-                    l_int32 maxboxes, l_int32 ovlap, const char *fileout,
-                    PIXA  *pixad);
+static void TestPartition(L_REGPARAMS *rp, const char *fname, l_int32 sorttype,
+                          l_int32 maxboxes, l_float32 ovlap,
+                          const char *fileout, PIXA  *pixad);
 
 int main(int    argc,
          char **argv)
@@ -68,13 +68,13 @@ L_REGPARAMS  *rp;
     lept_mkdir("lept/part");
 
     pixad = pixaCreate(4);  /* only for display */
-    TestPartition(rp, "test8.jpg", L_SORT_BY_HEIGHT, 20, 0.0, "test0.pdf",
+    TestPartition(rp, "test8.jpg", L_SORT_BY_HEIGHT, 20, 0.0f, "test0.pdf",
                   pixad);
-    TestPartition(rp, "test8.jpg", L_SORT_BY_AREA, 20, 0.0, "test1.pdf",
+    TestPartition(rp, "test8.jpg", L_SORT_BY_AREA, 20, 0.0f, "test1.pdf",
                   pixad);
-    TestPartition(rp, "test8.jpg", L_SORT_BY_AREA, 20, 0.4, "test2.pdf",
+    TestPartition(rp, "test8.jpg", L_SORT_BY_AREA, 20, 0.4f, "test2.pdf",
                   pixad);
-    TestPartition(rp, "feyn-fract.tif", L_SORT_BY_AREA, 20, 0.0, "test3.pdf",
+    TestPartition(rp, "feyn-fract.tif", L_SORT_BY_AREA, 20, 0.0f, "test3.pdf",
                   pixad);
 
         /* If display requested, make a tiled image of all the results */
@@ -90,9 +90,9 @@ L_REGPARAMS  *rp;
 }
 
 
-void
+static void
 TestPartition(L_REGPARAMS *rp, const char *fname, l_int32 sorttype,
-              l_int32 maxboxes, l_int32 ovlap, const char *fileout,
+              l_int32 maxboxes, l_float32 ovlap, const char *fileout,
               PIXA  *pixad)
 {
 char     pathout[256];

--- a/src/bmp.h
+++ b/src/bmp.h
@@ -107,18 +107,4 @@ typedef struct BMP_InfoHeader  BMP_IH;
 /*! Number of bytes in a BMP info header */
 #define BMP_IHBYTES  sizeof(BMP_IH)
 
-
-/*-------------------------------------------------------------*
- *           Align BMP headers on 4 byte boundaries            *
- *-------------------------------------------------------------*/
-
-/*! BMP_IH is misaligned, causing crashes on some big-endians.
- *  A packed struct forces alignment. */
-#if defined(__GNUC__)
-typedef struct __attribute__((__packed__)) {
-  BMP_FH bmpfh;
-  BMP_IH bmpih;
-} BMP_HEADER;
-#endif
-
 #endif  /* LEPTONICA_BMP_H */

--- a/src/scale2.c
+++ b/src/scale2.c
@@ -216,9 +216,9 @@ PIX       *pixt, *pixd;
         return (PIX *)ERROR_PTR("pixs not defined", __func__, NULL);
     if (pixGetDepth(pixs) != 1)
         return (PIX *)ERROR_PTR("pixs not 1 bpp", __func__, NULL);
-    if (scalefactor <= 0.0)
+    if (scalefactor <= 0.0f)
         return (PIX *)ERROR_PTR("scalefactor <= 0.0", __func__, NULL);
-    if (scalefactor >= 1.0)
+    if (scalefactor >= 1.0f)
         return (PIX *)ERROR_PTR("scalefactor >= 1.0", __func__, NULL);
     pixGetDimensions(pixs, &w, &h, NULL);
     minsrc = L_MIN(w, h);
@@ -226,58 +226,58 @@ PIX       *pixt, *pixd;
     if (mindest < 2)
         return (PIX *)ERROR_PTR("scalefactor too small", __func__, NULL);
 
-    if (scalefactor > 0.5) {   /* see note (5) */
+    if (scalefactor > 0.5f) {   /* see note (5) */
         mag = 2.0f * scalefactor;  /* will be < 2.0 */
 /*        lept_stderr("2x with mag %7.3f\n", mag);  */
         if ((pixt = pixScaleBinary(pixs, mag, mag)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
         pixd = pixScaleToGray2(pixt);
-    } else if (scalefactor == 0.5) {
+    } else if (scalefactor == 0.5f) {
         return pixd = pixScaleToGray2(pixs);
-    } else if (scalefactor > 0.33333) {   /* see note (5) */
+    } else if (scalefactor > 0.33333f) {   /* see note (5) */
         mag = 3.0f * scalefactor;   /* will be < 1.5 */
 /*        lept_stderr("3x with mag %7.3f\n", mag);  */
         if ((pixt = pixScaleBinary(pixs, mag, mag)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
         pixd = pixScaleToGray3(pixt);
-    } else if (scalefactor > 0.25) {  /* see note (5) */
+    } else if (scalefactor > 0.25f) {  /* see note (5) */
         mag = 4.0f * scalefactor;   /* will be < 1.3333 */
 /*        lept_stderr("4x with mag %7.3f\n", mag);  */
         if ((pixt = pixScaleBinary(pixs, mag, mag)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
         pixd = pixScaleToGray4(pixt);
-    } else if (scalefactor == 0.25) {
+    } else if (scalefactor == 0.25f) {
         return pixd = pixScaleToGray4(pixs);
-    } else if (scalefactor > 0.16667) {  /* see note (5) */
+    } else if (scalefactor > 0.16667f) {  /* see note (5) */
         mag = 6.0f * scalefactor;   /* will be < 1.5 */
 /*        lept_stderr("6x with mag %7.3f\n", mag); */
         if ((pixt = pixScaleBinary(pixs, mag, mag)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
         pixd = pixScaleToGray6(pixt);
-    } else if (scalefactor == 0.16667) {
+    } else if (scalefactor == 0.16667f) {
         return pixd = pixScaleToGray6(pixs);
-    } else if (scalefactor > 0.125) {  /* see note (5) */
+    } else if (scalefactor > 0.125f) {  /* see note (5) */
         mag = 8.0f * scalefactor;   /*  will be < 1.3333  */
 /*        lept_stderr("8x with mag %7.3f\n", mag);  */
         if ((pixt = pixScaleBinary(pixs, mag, mag)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
         pixd = pixScaleToGray8(pixt);
-    } else if (scalefactor == 0.125) {
+    } else if (scalefactor == 0.125f) {
         return pixd = pixScaleToGray8(pixs);
-    } else if (scalefactor > 0.0625) {  /* see note (6) */
+    } else if (scalefactor > 0.0625f) {  /* see note (6) */
         red = 8.0f * scalefactor;   /* will be > 0.5 */
 /*        lept_stderr("8x with red %7.3f\n", red);  */
         if ((pixt = pixScaleBinary(pixs, red, red)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
         pixd = pixScaleToGray8(pixt);
-    } else if (scalefactor == 0.0625) {
+    } else if (scalefactor == 0.0625f) {
         return pixd = pixScaleToGray16(pixs);
     } else {  /* see note (7) */
         red = 16.0f * scalefactor;  /* will be <= 1.0 */
 /*        lept_stderr("16x with red %7.3f\n", red);  */
         if ((pixt = pixScaleToGray16(pixs)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
-        if (red < 0.7)
+        if (red < 0.7f)
             pixd = pixScaleSmooth(pixt, red, red);  /* see note (3) */
         else
             pixd = pixScaleGrayLI(pixt, red, red);  /* see note (2) */
@@ -325,9 +325,9 @@ PIX       *pixt, *pixd;
         return (PIX *)ERROR_PTR("pixs not defined", __func__, NULL);
     if (pixGetDepth(pixs) != 1)
         return (PIX *)ERROR_PTR("pixs not 1 bpp", __func__, NULL);
-    if (scalefactor <= 0.0)
+    if (scalefactor <= 0.0f)
         return (PIX *)ERROR_PTR("scalefactor <= 0.0", __func__, NULL);
-    if (scalefactor >= 1.0)
+    if (scalefactor >= 1.0f)
         return (PIX *)ERROR_PTR("scalefactor >= 1.0", __func__, NULL);
     pixGetDimensions(pixs, &w, &h, NULL);
     minsrc = L_MIN(w, h);
@@ -337,20 +337,20 @@ PIX       *pixt, *pixd;
     eps = 0.0001f;
 
         /* Handle the special cases */
-    if (scalefactor > 0.5 - eps && scalefactor < 0.5 + eps)
+    if (scalefactor > 0.5f - eps && scalefactor < 0.5f + eps)
         return pixScaleToGray2(pixs);
-    else if (scalefactor > 0.33333 - eps && scalefactor < 0.33333 + eps)
+    else if (scalefactor > 0.33333f - eps && scalefactor < 0.33333f + eps)
         return pixScaleToGray3(pixs);
-    else if (scalefactor > 0.25 - eps && scalefactor < 0.25 + eps)
+    else if (scalefactor > 0.25f - eps && scalefactor < 0.25f + eps)
         return pixScaleToGray4(pixs);
-    else if (scalefactor > 0.16666 - eps && scalefactor < 0.16666 + eps)
+    else if (scalefactor > 0.16666f - eps && scalefactor < 0.16666f + eps)
         return pixScaleToGray6(pixs);
-    else if (scalefactor > 0.125 - eps && scalefactor < 0.125 + eps)
+    else if (scalefactor > 0.125f - eps && scalefactor < 0.125f + eps)
         return pixScaleToGray8(pixs);
-    else if (scalefactor > 0.0625 - eps && scalefactor < 0.0625 + eps)
+    else if (scalefactor > 0.0625f - eps && scalefactor < 0.0625f + eps)
         return pixScaleToGray16(pixs);
 
-    if (scalefactor > 0.0625) {  /* scale binary first */
+    if (scalefactor > 0.0625f) {  /* scale binary first */
         factor = 2.0f * scalefactor;
         if ((pixt = pixScaleBinary(pixs, factor, factor)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
@@ -359,7 +359,7 @@ PIX       *pixt, *pixd;
         factor = 16.0f * scalefactor;  /* will be < 1.0 */
         if ((pixt = pixScaleToGray16(pixs)) == NULL)
             return (PIX *)ERROR_PTR("pixt not made", __func__, NULL);
-        if (factor < 0.7)
+        if (factor < 0.7f)
             pixd = pixScaleSmooth(pixt, factor, factor);
         else
             pixd = pixScaleGrayLI(pixt, factor, factor);


### PR DESCRIPTION
The clang compiler reports several annoying warnings. Some of them have already been reported as an issue:

    ../src/bmpio.c:169:37: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:186:31: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:187:32: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:188:31: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:189:36: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:190:30: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:191:30: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:610:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:611:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:612:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:613:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:614:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:615:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:616:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:617:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:618:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/bmpio.c:619:5: warning: taking address of packed member 'bmpih' of class or structure 'BMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
    ../src/scale2.c:257:28: warning: floating-point comparison is always false; constant cannot be represented exactly in type 'float' [-Wliteral-range]
    ../prog/partition_reg.c:75:56: warning: implicit conversion from 'double' to 'l_int32' (aka 'int') changes value from 0.4 to 0 [-Wliteral-conversion]

Fix issue #750 and two other warnings which might even be classified as bugs.