### PR TITLE
Remove broken CMake config files from autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,12 +5,6 @@ EXTRA_DIST = config README.html leptonica-license.txt moller52.jpg version-notes
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = lept.pc
 
-# Cmake configs:
-lept_cmakeconfigdir = $(libdir)/cmake/
-lept_cmakeconfig_DATA = \
-	cmake/templates/LeptonicaConfig.cmake \
-	cmake/templates/LeptonicaConfig-version.cmake
-
 SUBDIRS = src prog
 
 # The fuzzing tests are run by OSS-Fuzz https://oss-fuzz.com/,

--- a/configure.ac
+++ b/configure.ac
@@ -267,8 +267,6 @@ AC_SUBST([VERSION_PATCH], [$(echo "$AX_POINT_VERSION" | $SED 's/^\([[0-9]][[0-9]
 INCLUDE_PATH=`eval echo $includedir`
 AC_SUBST([INCLUDE_DIR], ["${INCLUDE_PATH}/leptonica"])
 AC_SUBST([leptonica_OUTPUT_NAME], ["leptonica"])
-AC_CONFIG_FILES(cmake/templates/LeptonicaConfig.cmake)
-AC_CONFIG_FILES(cmake/templates/LeptonicaConfig-version.cmake)
 
 # Create symlink
 AC_PROG_LN_S


### PR DESCRIPTION
To fix #757 by removing the broken files. It isn't simple to generate CMake config target file. Could store a generated copy from CMake, but would need to make sure it doesn't go out-of-sync and regenerate it as necessary.