### PR TITLE
Add CTest support and option to skip test progs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,4 +48,8 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: sudo cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install
+
+    - name: Test
+      if: runner.os == 'Linux'
+      run: ctest --test-dir ${{github.workspace}}/build
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ project(
   leptonica
   LANGUAGES C
   VERSION 1.85.1)
+include(CTest)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 

--- a/prog/CMakeLists.txt
+++ b/prog/CMakeLists.txt
@@ -1,10 +1,31 @@
+set (MANUAL_REG_PROGS
+    alltests_reg bilateral1_reg
+    binmorph2_reg binmorph4_reg binmorph5_reg
+    dwamorph2_reg
+    files_reg fmorphauto_reg
+    morphseq_reg pixalloc_reg pixtile_reg
+    smoothedge_reg
+)
 
 set(math_progs "blend4_reg|dna_reg|extrema_reg|insert_reg|locminmax_reg|numa1_reg|otsutest1|pixalloc_reg|plottest|pta_reg|rankhisto_reg|rotatefastalt|watershed_reg")
+
+file(RELATIVE_PATH relative_reg_dir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
 ########################################
 # FUNCTION add_prog_target
 ########################################
 function(add_prog_target target)
+    if(${target} MATCHES "_reg$")
+        if(NOT BUILD_TESTING)
+            return()
+        endif()
+        if(NOT target IN_LIST MANUAL_REG_PROGS)
+            add_test(NAME ${target}
+                     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/reg_wrapper.sh ${relative_reg_dir}/${target}
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            set_tests_properties(${target} PROPERTIES SKIP_RETURN_CODE 78)
+        endif()
+    endif()
     set                             (${target}_src "${ARGN}")
     add_executable                  (${target} ${${target}_src})
     string(FIND ${target} "gif" GIF_TEST_FOUND)
@@ -15,7 +36,7 @@ function(add_prog_target target)
     if (BUILD_SHARED_LIBS)
         target_compile_definitions  (${target} PRIVATE -DLIBLEPT_IMPORTS)
     endif()
-    if(FREEBSD AND HAVE_LIBM AND ${target} MATCHES ${math_progs})
+    if(HAVE_LIBM AND ${target} MATCHES ${math_progs})
       target_link_libraries         (${target} leptonica m)
     else()
       target_link_libraries         (${target} leptonica)

--- a/prog/reg_wrapper.sh
+++ b/prog/reg_wrapper.sh
@@ -41,7 +41,7 @@ case "${TEST_NAME}" in
         GNUPLOT=$(which gnuplot || which wgnuplot)
 
         if [ -z "${GNUPLOT}" ] || [ -n "$(${GNUPLOT} -e 'set terminal png' 2>&1)" ] ; then
-            exec ${@%${TEST}} /bin/sh -c "exit 77"
+            exec ${@%${TEST}} /bin/sh -c "exit 78"
         fi
 esac
 


### PR DESCRIPTION
Partially fix #759 when building for distribution that doesn't care about test programs. Similar idea to how CTest `-DBUILD_TESTING=OFF` or GNOME's common meson `-Dtests=disabled` usually avoids compiling unnecessary files.

Build can still fail on Linux/glibc when `-DBUILD_TESTING=ON` as some progs needs `-lm` but lower priority for packaging which is my main concern.

Used `BUILD_TESTING` option as that is default for CTest[^1] so can be compatible if future switch to `include(CTest)`.

Note that CI does not test this as `BUILD_PROG=OFF` for Linux:
https://github.com/DanBloomberg/leptonica/blob/96a3d7451e7d717d8a0c88436f5ff7ea7129412e/.github/workflows/cmake.yml#L46


[^1]: https://cmake.org/cmake/help/latest/module/CTest.html