### PR TITLE
Fix use-after-free in morphSequenceVerify()

### DIFF
--- a/src/morphseq.c
+++ b/src/morphseq.c
@@ -842,7 +842,7 @@ l_int32  intlogbase2[5] = {1, 2, 3, 0, 4};  /* of arg/4 */
     }
 
     if (border != 0 && netred != 0) {
-        lept_stderr("*** op = %s; border added but net reduction not 0\n", op);
+        lept_stderr("*** border added but net reduction not 0\n");
         valid = FALSE;
     }
     return valid;


### PR DESCRIPTION
Remove reference to freed 'op' pointer in error message at line 845. The pointer is freed at line 841 in the last loop iteration, then used in the post-loop error check. Replace with a fixed error string that does not reference 'op'.