### PR TITLE
ci: add permissions and pin third-party action SHAs

### DIFF
--- a/.github/workflows/autotools-macos.yml
+++ b/.github/workflows/autotools-macos.yml
@@ -23,6 +23,9 @@ on:
   # Trigger workflow in GitHub web frontend or from API.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   brew:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -10,6 +10,9 @@ on:
     - '**.h'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake-win64.yml
+++ b/.github/workflows/cmake-win64.yml
@@ -12,12 +12,15 @@ on:
 env:
   ILOC: d:/a/local
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: cmake-win64
     runs-on: windows-latest
     steps:
-      - uses: ilammy/setup-nasm@v1
+      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b  # v1
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,6 +13,9 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -53,4 +56,3 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: sudo cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install
-

--- a/.github/workflows/sw.yml
+++ b/.github/workflows/sw.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: egorpugin/sw-action@0261dc5095b3c7688d7ad1a429ea53d9b239ad6f  # master
+    - uses: egorpugin/sw-action@master
     - run: ./sw build -static -shared -config d,r
     
   linux:
@@ -35,14 +35,14 @@ jobs:
       run: |
         sudo dnf -y update
         sudo dnf -y install cmake which g++ clang clang-tools-extra lld
-    - uses: egorpugin/sw-action@0261dc5095b3c7688d7ad1a429ea53d9b239ad6f  # master
+    - uses: egorpugin/sw-action@master
     - run: ./sw build -static -shared -config d,r
    
   macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: egorpugin/sw-action@0261dc5095b3c7688d7ad1a429ea53d9b239ad6f  # master
+    - uses: egorpugin/sw-action@master
     - name: install
       run: |
         brew update

--- a/.github/workflows/sw.yml
+++ b/.github/workflows/sw.yml
@@ -15,12 +15,15 @@ on:
 #      - '.github/*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: egorpugin/sw-action@master
+    - uses: egorpugin/sw-action@0261dc5095b3c7688d7ad1a429ea53d9b239ad6f  # master
     - run: ./sw build -static -shared -config d,r
     
   linux:
@@ -32,14 +35,14 @@ jobs:
       run: |
         sudo dnf -y update
         sudo dnf -y install cmake which g++ clang clang-tools-extra lld
-    - uses: egorpugin/sw-action@master
+    - uses: egorpugin/sw-action@0261dc5095b3c7688d7ad1a429ea53d9b239ad6f  # master
     - run: ./sw build -static -shared -config d,r
    
   macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: egorpugin/sw-action@master
+    - uses: egorpugin/sw-action@0261dc5095b3c7688d7ad1a429ea53d9b239ad6f  # master
     - name: install
       run: |
         brew update


### PR DESCRIPTION
> **AI assistance disclosure:** This pull request was prepared with AI assistance. The changes are mechanical CI/CD hardening; I reviewed and validated each workflow change myself, and I take responsibility for the contribution.

---

## Summary

This narrows GitHub Actions workflow privileges and pins only non-provider third-party actions to immutable revisions.

**Changes:**
- Add explicit `permissions: contents: read` to build/fuzzing workflows that only need repository read access.
- Pin `ilammy/setup-nasm` and `egorpugin/sw-action` to commit SHAs because they are third-party actions.
- Leave GitHub-owned actions, Google OSS-Fuzz actions, and the Fedora container tag on their existing tags per maintainer preference for trusted provider updates.

I verified the workflow YAML still parses and `git diff --check` passes. I also re-ran `zizmor`; the remaining high-confidence findings are the intentionally unpinned trusted provider refs and `fedora:latest` tag discussed in review.
