### PR TITLE
Update Leptonica include directories configuration

### DIFF
--- a/cmake/templates/LeptonicaConfig.cmake.in
+++ b/cmake/templates/LeptonicaConfig.cmake.in
@@ -44,7 +44,10 @@ SET(Leptonica_VERSION_PATCH     @leptonica_VERSION_PATCH@)
 # ======================================================
 
 # Provide the include directories to the caller
-set(Leptonica_INCLUDE_DIRS      "@INCLUDE_DIR@")
+get_filename_component(_IMPORTED_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+set(INCLUDE_DIR "${_IMPORTED_ROOT}/include" "${_IMPORTED_ROOT}/include/leptonica")
+
+set(Leptonica_INCLUDE_DIRS ${INCLUDE_DIR})
 
 # ====================================================================
 # Link libraries:

--- a/cmake/templates/LeptonicaConfig.cmake.in
+++ b/cmake/templates/LeptonicaConfig.cmake.in
@@ -44,10 +44,30 @@ SET(Leptonica_VERSION_PATCH     @leptonica_VERSION_PATCH@)
 # ======================================================
 
 # Provide the include directories to the caller
-get_filename_component(_IMPORTED_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-set(INCLUDE_DIR "${_IMPORTED_ROOT}/include" "${_IMPORTED_ROOT}/include/leptonica")
+# Recover install prefix from the location of this file (supports multi-arch libdirs).
+file(TO_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}" _lept_cfg_dir)
+file(TO_CMAKE_PATH "@leptonica_INSTALL_CMAKE_DIR@" _lept_rel_cmake_dir)
+string(REGEX REPLACE "/$" "" _lept_cfg_dir "${_lept_cfg_dir}")
+string(REGEX REPLACE "/$" "" _lept_rel_cmake_dir "${_lept_rel_cmake_dir}")
 
-set(Leptonica_INCLUDE_DIRS ${INCLUDE_DIR})
+set(_lept_suffix "/${_lept_rel_cmake_dir}")
+string(LENGTH "${_lept_cfg_dir}" _lept_cfg_len)
+string(LENGTH "${_lept_suffix}" _lept_suffix_len)
+
+unset(_lept_tail)
+if(_lept_cfg_len GREATER _lept_suffix_len)
+  math(EXPR _lept_prefix_len "${_lept_cfg_len} - ${_lept_suffix_len}")
+  string(SUBSTRING "${_lept_cfg_dir}" ${_lept_prefix_len} ${_lept_suffix_len} _lept_tail)
+endif()
+
+if(DEFINED _lept_tail AND _lept_tail STREQUAL "${_lept_suffix}")
+  string(SUBSTRING "${_lept_cfg_dir}" 0 ${_lept_prefix_len} _IMPORTED_ROOT)
+else()
+  # Fallback to the configured prefix if the expected suffix doesn't match.
+  set(_IMPORTED_ROOT "@CMAKE_INSTALL_PREFIX@")
+endif()
+
+set(Leptonica_INCLUDE_DIRS "${_IMPORTED_ROOT}/include" "${_IMPORTED_ROOT}/include/leptonica")
 
 # ====================================================================
 # Link libraries:


### PR DESCRIPTION
Fixed an issue where Leptonica was placed in a location other than the one installed at compile time when referencing through cmake in other projects, resulting in incorrect path positioning
```
find_package(Leptonica REQUIRED)
message(STATUS Leptonica_FOUND:${Leptonica_FOUND})
message(STATUS Leptonica_INCLUDE_DIRS:${Leptonica_INCLUDE_DIRS})
message(STATUS Leptonica_LIBRARIES:${Leptonica_LIBRARIES})

target_include_directories(${PROJECT_NAME} PUBLIC ${Leptonica_INCLUDE_DIRS})
target_link_libraries(${PROJECT_NAME} ${Leptonica_LIBRARIES})
```